### PR TITLE
feat: local TeamStorage

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -87,7 +87,8 @@ slack.application.client-secret=<client_secret>
 slack.application.signing=<signing secret>
 --
 
-If you want to provide your own link:starter/slack-spring-boot-autoconfigure/src/main/kotlin/io/olaph/slack/broker/autoconfiguration/CredentialsProvider.kt[CredentialsProvider] implementation
+If you want to provide your own link:starter/slack-spring-boot-autoconfigure/src/main/kotlin/io/olaph/slack/broker/autoconfiguration/CredentialsProvider.kt[CredentialsProvider] implement the interface
+and expose it as a Bean/Component
 
 Start your application
 [source]

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ allprojects {
     version = rootProject.file("version.txt").text.trim()
 
     project.ext {
-        junitJupiterVersion = "5.3.1"
-        junitPlatformVersion = "1.3.1"
+        junitJupiterVersion = "5.4.2"
+        junitPlatformVersion = "1.4.2"
         springBootVersion = "2.1.3.RELEASE"
         projectVersion = version
         kotlinVersion = "1.3.21"
@@ -152,12 +152,7 @@ subprojects {
     dependencies {
 
         testImplementation(group: "com.nhaarman.mockitokotlin2", name: "mockito-kotlin", version: "2.0.0")
-        testImplementation(group: "org.junit.jupiter", name: "junit-jupiter-params", version: "${junitJupiterVersion}")
-        testImplementation(group: "org.junit.jupiter", name: "junit-jupiter-api", version: "${junitJupiterVersion}")
-        testRuntime(group: "org.junit.jupiter", name: "junit-jupiter-engine", version: "${junitJupiterVersion}")
-        testImplementation(group: "org.junit.platform", name: "junit-platform-runner", version: "${junitPlatformVersion}") {
-            exclude(group: "junit", module: "junit")
-        }
+        testImplementation(group: "org.junit.jupiter", name: "junit-jupiter", version: "${junitJupiterVersion}")
     }
 
 }

--- a/samples/slack-spring-boot-starter-sample/src/main/resources/application.properties
+++ b/samples/slack-spring-boot-starter-sample/src/main/resources/application.properties
@@ -2,3 +2,4 @@ debug=true
 management.endpoints.web.exposure.include=health,info,metrics
 slack.installation.success-redirect-url=
 slack.installation.error-redirect-url=
+slack.store.type=file

--- a/starter/slack-spring-boot-autoconfigure/src/main/kotlin/io/olaph/slack/broker/autoconfiguration/SlackBrokerAutoconfiguration.kt
+++ b/starter/slack-spring-boot-autoconfigure/src/main/kotlin/io/olaph/slack/broker/autoconfiguration/SlackBrokerAutoconfiguration.kt
@@ -27,6 +27,7 @@ import io.olaph.slack.broker.receiver.MismatchCommandReciever
 import io.olaph.slack.broker.receiver.SL4JLoggingReceiver
 import io.olaph.slack.broker.receiver.SlashCommandReceiver
 import io.olaph.slack.broker.store.InMemoryTeamStore
+import io.olaph.slack.broker.store.FileTeamStore
 import io.olaph.slack.broker.store.TeamStore
 import io.olaph.slack.client.SlackClient
 import io.olaph.slack.client.spring.DefaultSlackClient
@@ -48,10 +49,18 @@ open class SlackBrokerAutoConfiguration {
     @Configuration
     open class BrokerAutoConfiguration(private val configuration: SlackBrokerConfigurationProperties, private val credentialsProvider: CredentialsProvider) : WebMvcConfigurer {
 
+        @ConditionalOnProperty(prefix = SlackBrokerConfigurationProperties.TEAM_STORE, name = ["type"], havingValue = "memory", matchIfMissing = true)
         @ConditionalOnMissingBean
         @Bean
         open fun teamStore(): TeamStore {
             return InMemoryTeamStore()
+        }
+
+        @ConditionalOnProperty(prefix = SlackBrokerConfigurationProperties.TEAM_STORE, name = ["type"], havingValue = "file")
+        @ConditionalOnMissingBean
+        @Bean
+        open fun localTeamStore() : TeamStore {
+            return FileTeamStore()
         }
 
         @Bean

--- a/starter/slack-spring-boot-autoconfigure/src/main/kotlin/io/olaph/slack/broker/autoconfiguration/SlackBrokerConfigurationProperties.kt
+++ b/starter/slack-spring-boot-autoconfigure/src/main/kotlin/io/olaph/slack/broker/autoconfiguration/SlackBrokerConfigurationProperties.kt
@@ -6,12 +6,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = SlackBrokerConfigurationProperties.PROPERTY_PREFIX)
 open class SlackBrokerConfigurationProperties {
 
+
     companion object {
         const val PROPERTY_PREFIX = "slack"
         const val INSTALLATION_PROPERTY_PREFIX = "$PROPERTY_PREFIX.installation"
         const val LOGGING_PROPERTY_PREFIX = "$PROPERTY_PREFIX.logging"
         const val COMMANDS_PROPERTY_PREFIX = "$PROPERTY_PREFIX.commands"
         const val MISMATCH_PROPERTY_PREFIX = "$COMMANDS_PROPERTY_PREFIX.mismatch"
+        const val TEAM_STORE = "$PROPERTY_PREFIX.store"
     }
 
     /**
@@ -22,6 +24,8 @@ open class SlackBrokerConfigurationProperties {
     var logging: Logging = Logging()
 
     var commands: Commands = Commands()
+
+    var store: Store = Store()
 
 
     open class Installation {
@@ -59,7 +63,15 @@ open class SlackBrokerConfigurationProperties {
 
             var text: String = "I am sorry i was not able to understand this"
         }
+    }
 
+    open class Store {
+
+        lateinit var type: Type
+
+        enum class Type {
+            MEMORY, FILE
+        }
 
     }
 }

--- a/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/TeamStoreAutoConfigurationTests.kt
+++ b/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/TeamStoreAutoConfigurationTests.kt
@@ -1,5 +1,6 @@
 package io.olaph.slack.broker.autoconfiguration
 
+import io.olaph.slack.broker.store.FileTeamStore
 import io.olaph.slack.broker.store.InMemoryTeamStore
 import io.olaph.slack.broker.store.Team
 import io.olaph.slack.broker.store.TeamStore
@@ -23,6 +24,24 @@ class TeamStoreAutoConfigurationTests {
                     Assertions.assertDoesNotThrow { it.getBean(TeamStore::class.java) }
                     Assertions.assertTrue(it.getBean(TeamStore::class.java) is TestTeamStore)
                 }
+
+        TestApplicationContext.base()
+                .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                .withUserConfiguration(TestConfiguration::class.java)
+                .withPropertyValues("slack.store.type:memory")
+                .run {
+                    Assertions.assertDoesNotThrow { it.getBean(TeamStore::class.java) }
+                    Assertions.assertTrue(it.getBean(TeamStore::class.java) is TestTeamStore)
+                }
+
+        TestApplicationContext.base()
+                .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                .withUserConfiguration(TestConfiguration::class.java)
+                .withPropertyValues("slack.store.type:file")
+                .run {
+                    Assertions.assertDoesNotThrow { it.getBean(TeamStore::class.java) }
+                    Assertions.assertTrue(it.getBean(TeamStore::class.java) is TestTeamStore)
+                }
     }
 
     @DisplayName("InMemoryTeamStore Registration")
@@ -30,9 +49,22 @@ class TeamStoreAutoConfigurationTests {
     fun teamStoreRegistration() {
         TestApplicationContext.base()
                 .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                .withPropertyValues("slack.store.type:memory")
                 .run {
                     Assertions.assertDoesNotThrow { it.getBean(TeamStore::class.java) }
                     Assertions.assertTrue(it.getBean(TeamStore::class.java) is InMemoryTeamStore)
+                }
+    }
+
+    @DisplayName("File TeamStore Registration")
+    @Test
+    fun fileTeamStoreRegistration() {
+        TestApplicationContext.base()
+                .withConfiguration(AutoConfigurations.of(SlackBrokerAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
+                .withPropertyValues("slack.store.type:file")
+                .run {
+                    Assertions.assertDoesNotThrow { it.getBean(FileTeamStore::class.java) }
+                    Assertions.assertTrue(it.getBean(TeamStore::class.java) is FileTeamStore)
                 }
     }
 
@@ -41,9 +73,7 @@ class TeamStoreAutoConfigurationTests {
     open class TestConfiguration {
 
         @Bean
-        open fun testTeamStore(): TeamStore {
-            return TestTeamStore()
-        }
+        open fun testTeamStore(): TeamStore = TestTeamStore()
     }
 
     class TestTeamStore : TeamStore {
@@ -53,5 +83,7 @@ class TeamStoreAutoConfigurationTests {
         override fun put(team: Team) {}
 
         override fun removeById(id: String) {}
+
     }
+
 }

--- a/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/TestApplicationContext.kt
+++ b/starter/slack-spring-boot-autoconfigure/src/test/kotlin/io/olaph/slack/broker/autoconfiguration/TestApplicationContext.kt
@@ -4,7 +4,6 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner
 
 object TestApplicationContext {
 
-
     fun base(): WebApplicationContextRunner {
         return WebApplicationContextRunner()
                 .withSystemProperties("slack.application.client-id:id",

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/FileTeamStore.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/FileTeamStore.kt
@@ -1,0 +1,173 @@
+package io.olaph.slack.broker.store
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.olaph.slack.dto.jackson.JacksonDataClass
+import org.apache.commons.io.FileUtils
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.nio.charset.Charset
+
+/**
+ * Default implementation of a local TeamStore
+ * This implementation is meant for develop environments
+ */
+class FileTeamStore : TeamStore {
+
+
+    companion object {
+
+        private val LOG = LoggerFactory.getLogger(FileTeamStore::class.java)
+
+        private const val fileName = "team-store.json"
+        private val objectMapper = ObjectMapper()
+
+        /**
+         * Methods to set up the directory and the storage file
+         */
+        private fun homeDirectory(): String = System.getProperty("user.home")
+                ?: throw Exception("Unable to load credentials:'user.home' System property is not set.")
+
+        private fun dataFile(): File = File(homeDirectory(), ".slack/$fileName")
+
+    }
+
+    /**
+     * File should be already present.
+     * Creates the file in case it is missing
+     */
+    init {
+        if (!dataFile().exists()) {
+            LOG.info("Did not find credentials file under ${dataFile().absolutePath}. Attempting to create it")
+            dataFile().parentFile.mkdirs()
+            dataFile().createNewFile()
+            objectMapper.writeValue(dataFile(), listOf<LocalTeam>())
+            LOG.info("$fileName successfully created under ${dataFile().absolutePath}")
+        } else if (dataFile().exists() && dataFile().isFile) {
+            LOG.info("$fileName found")
+            if (dataFile().length() == 0L) {
+                LOG.info("File is empty, initializing with emtpty array")
+                objectMapper.writeValue(dataFile(), listOf<LocalTeam>())
+            }
+        } else {
+            LOG.error("Could not create file")
+            throw IllegalStateException("$fileName seems to be a directory")
+        }
+    }
+
+
+    /**
+     * Operations on the local file
+     */
+    override fun findById(id: String): Team {
+        val localTeams: List<LocalTeam> = objectMapper.readValue(dataFile())
+
+        // Find the team with the given id in the list that was retrieved from the file
+        val team = localTeams.find { it.teamId == id } ?: throw TeamNotFoundException("Team $id not found.")
+
+        return Team(
+                teamId = team.teamId,
+                teamName = team.teamName,
+                incomingWebhook = Team.IncomingWebhook(
+                        channel = team.incomingWebhook.channel,
+                        channelId = team.incomingWebhook.channelId,
+                        configurationUrl = team.incomingWebhook.configurationUrl,
+                        url = team.incomingWebhook.url
+                ),
+                bot = Team.Bot(
+                        userId = team.bot.userId,
+                        accessToken = team.bot.accessToken
+                ))
+    }
+
+    override fun put(team: Team) {
+
+        LOG.info("Inserting $team")
+        val file = dataFile()
+
+        val origin: List<LocalTeam> = objectMapper.readValue(file)
+
+        // Build an Object out of the team that is given in via parameter
+        val localTeam = LocalTeam(
+                teamId = team.teamId,
+                teamName = team.teamName,
+                incomingWebhook = LocalTeam.IncomingWebhook(
+                        channel = team.incomingWebhook.channel,
+                        channelId = team.incomingWebhook.channelId,
+                        configurationUrl = team.incomingWebhook.configurationUrl,
+                        url = team.incomingWebhook.url
+                ),
+                bot = LocalTeam.Bot(
+                        userId = team.bot.userId,
+                        accessToken = team.bot.accessToken
+                )
+        )
+
+        val result = origin.plus(localTeam)
+        FileUtils.write(file, objectMapper.writeValueAsString(result), Charset.forName("UTF-8"))
+    }
+
+    override fun removeById(id: String) {
+
+        val origin: List<LocalTeam> = objectMapper.readValue(dataFile())
+
+        val teamToRemove = origin.find { it.teamId == id }
+
+        teamToRemove?.let {
+            objectMapper.writeValue(dataFile(), origin.minus(it))
+        }
+
+    }
+
+    @JacksonDataClass
+    data class LocalTeam(@field: JsonProperty("team_id")
+                         @param: JsonProperty("team_id")
+                         val teamId: String,
+
+                         @field: JsonProperty("team_name")
+                         @param: JsonProperty("team_name")
+                         val teamName: String,
+
+                         @field: JsonProperty("incoming_webhook")
+                         @param: JsonProperty("incoming_webhook")
+                         val incomingWebhook: IncomingWebhook,
+
+                         @field: JsonProperty("bot")
+                         @param: JsonProperty("bot")
+                         val bot: Bot) {
+        companion object {}
+
+        @JacksonDataClass
+        data class Bot(
+                @field: JsonProperty("user_id")
+                @param: JsonProperty("user_id")
+                val userId: String,
+
+                @field: JsonProperty("access_token")
+                @param: JsonProperty("access_token")
+                val accessToken: String) {
+            companion object
+        }
+
+        @JacksonDataClass
+        data class IncomingWebhook(
+                @field:JsonProperty("channel")
+                @param: JsonProperty("channel")
+                val channel: String,
+
+                @field: JsonProperty("channel_id")
+                @param: JsonProperty("channel_id")
+                val channelId: String,
+
+                @field: JsonProperty("configuration_rl")
+                @param: JsonProperty("configuration_rl")
+                val configurationUrl: String,
+
+                @field: JsonProperty("url")
+                @param: JsonProperty("url")
+                val url: String) {
+            companion object
+        }
+    }
+}

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/InMemoryTeamStore.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/InMemoryTeamStore.kt
@@ -1,0 +1,20 @@
+package io.olaph.slack.broker.store
+
+/**
+ * In Memory TeamStore
+ * This Default implementation should not be used on production environments
+ */
+class InMemoryTeamStore(private val teams: MutableMap<String, Team> = mutableMapOf()) : TeamStore {
+
+    override fun findById(id: String): Team {
+        return teams[id] ?: throw TeamNotFoundException("team with id $id not found")
+    }
+
+    override fun put(team: Team) {
+        teams[team.teamId] = team
+    }
+
+    override fun removeById(id: String) {
+        teams.remove(id)
+    }
+}

--- a/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/TeamStore.kt
+++ b/starter/slack-spring-boot/src/main/kotlin/io/olaph/slack/broker/store/TeamStore.kt
@@ -10,7 +10,6 @@ interface TeamStore {
      */
     fun findById(id: String): Team
 
-
     /**
      * Adds a Team to the Database
      */
@@ -48,21 +47,3 @@ data class Team(val teamId: String,
     }
 }
 
-/**
- * Default implementation for TeamStore
- * This Default implementation should not be used on production environments
- */
-class InMemoryTeamStore(private val teams: MutableMap<String, Team> = mutableMapOf()) : TeamStore {
-
-    override fun findById(id: String): Team {
-        return teams[id] ?: throw TeamNotFoundException("team with id $id not found")
-    }
-
-    override fun put(team: Team) {
-        teams[team.teamId] = team
-    }
-
-    override fun removeById(id: String) {
-        teams.remove(id)
-    }
-}

--- a/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/store/FileTeamStoreTests.kt
+++ b/starter/slack-spring-boot/src/test/kotlin/io/olaph/slack/broker/store/FileTeamStoreTests.kt
@@ -1,0 +1,198 @@
+package io.olaph.slack.broker.store
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.olaph.slack.broker.extensions.sample
+import org.apache.commons.io.FileUtils
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ConditionEvaluationResult
+import org.junit.jupiter.api.extension.ExecutionCondition
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.io.File
+import java.nio.charset.Charset
+
+@ExtendWith(FileTeamStoreTests.DisabledOnExistingTeamStoreFile::class)
+@DisplayName("LocalTeamStore Test")
+internal class FileTeamStoreTests {
+
+    companion object {
+        private fun dataFile(): File = File(System.getProperty("user.home"), ".slack/team-store.json")
+
+        private fun createFile() {
+            dataFile().parentFile.mkdirs()
+            dataFile().createNewFile()
+        }
+
+        private fun deleteFile() {
+            dataFile().deleteRecursively()
+        }
+    }
+
+    @Nested
+    @DisplayName("Initialization Tests")
+    inner class InitializationTests {
+
+
+        @DisplayName("File does not exist and no user home can be found")
+        @Test
+        fun fileDoesNotExistWhileNoUserHome() {
+            //setup
+
+            val userHome = System.getProperty("user.home")
+            System.clearProperty("user.home")
+
+            //test
+            Assertions.assertThrows(Exception::class.java) { FileTeamStore() }
+
+            //cleanup
+            System.setProperty("user.home", userHome)
+        }
+
+        @DisplayName("File does not exist")
+        @Test
+        fun fileDoesNotExist() {
+
+            // setup
+            FileTeamStore()
+
+            //test
+            Assertions.assertTrue(dataFile().exists())
+            val list: List<FileTeamStore.LocalTeam> = jacksonObjectMapper().readValue(dataFile())
+            Assertions.assertEquals(listOf<FileTeamStore.LocalTeam>(), list)
+
+            dataFile().deleteRecursively()
+        }
+
+        @DisplayName("File exist but is empty")
+        @Test
+        fun fileExistButEmpty() {
+
+            dataFile().parentFile.mkdirs()
+            dataFile().createNewFile()
+
+            // setup
+            FileTeamStore()
+
+            //test
+            Assertions.assertTrue(dataFile().length() == 2L)
+            val list: List<FileTeamStore.LocalTeam> = jacksonObjectMapper().readValue(dataFile())
+            Assertions.assertEquals(listOf<FileTeamStore.LocalTeam>(), list)
+
+            dataFile().deleteRecursively()
+        }
+
+        @DisplayName("File exist not empty")
+        @Test
+        fun fileExistNotEmpty() {
+
+            dataFile().parentFile.mkdirs()
+            dataFile().createNewFile()
+            FileUtils.write(dataFile(), "[]", Charset.forName("UTF-8"))
+
+            // setup
+            FileTeamStore()
+
+            //test
+            Assertions.assertTrue(dataFile().length() == 2L)
+            val list: List<FileTeamStore.LocalTeam> = jacksonObjectMapper().readValue(dataFile())
+            Assertions.assertEquals(listOf<FileTeamStore.LocalTeam>(), list)
+
+            dataFile().deleteRecursively()
+        }
+
+        @DisplayName("File exist but is directory")
+        @Test
+        fun fileExistButIsDirectory() {
+
+            // setup
+            dataFile().mkdirs()
+
+            //test
+            Assertions.assertThrows(IllegalStateException::class.java) { FileTeamStore() }
+
+
+            dataFile().deleteRecursively()
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Operation Tests")
+    inner class OperationTests {
+
+
+        @Test
+        @DisplayName("Exception On Non Existent Team")
+        fun findNonExistentTeam() {
+
+            createFile()
+
+            // test
+            Assertions.assertThrows(TeamNotFoundException::class.java) { FileTeamStore().findById(Team.sample().teamId) }
+
+            //cleanup
+            deleteFile()
+        }
+
+        @Test
+        @DisplayName("Add Team")
+        fun addTeam() {
+            // setup
+            createFile()
+            FileTeamStore().put(Team.sample())
+
+            // test
+            Assertions.assertEquals(Team.sample(), FileTeamStore().findById(Team.sample().teamId))
+
+            //cleanup
+            deleteFile()
+        }
+
+        @DisplayName("Test Add and Remove")
+        @Test
+        fun removeTeam() {
+            createFile()
+            FileTeamStore().put(Team.sample())
+
+            // test
+            FileTeamStore().removeById(Team.sample().teamId)
+
+            Assertions.assertThrows(TeamNotFoundException::class.java) { FileTeamStore().findById(Team.sample().teamId) }
+
+            //cleanup
+            deleteFile()
+        }
+
+        @DisplayName("Remove Non Existent")
+        @Test
+        fun removeNonExistent() {
+            //setup
+            createFile()
+            val localTeamStore = FileTeamStore()
+
+            //test
+            Assertions.assertDoesNotThrow { localTeamStore.removeById("missingTeamID") }
+
+            //cleanup
+            deleteFile()
+        }
+
+    }
+
+    class DisabledOnExistingTeamStoreFile : ExecutionCondition {
+
+        override fun evaluateExecutionCondition(context: ExtensionContext?): ConditionEvaluationResult {
+            return if (dataFile().exists()) {
+                ConditionEvaluationResult.disabled("TeamStore File Already Present")
+            } else {
+                ConditionEvaluationResult.enabled("No TeamStore File Present")
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## What problem are you trying to solve or corresponding Issue
<!--- Tell us what problem this improvement will solve or which issue it resolves -->
Creates a local file for team-storage instead of using inMemory-Storage in order to keep teams to prevent a re-installation every time while testing

## Current Behavior
<!--- Tell us what happens instead of the expected behavior -->
Usage of InMemory-Teamstorage

## Improvement/New Behavior
<!--- Provide a detailed description of the change or addition you are proposing -->

closes #200