### PR TITLE
Conversation DTO name-property is now nullable

### DIFF
--- a/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/common/types/Conversation.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/common/types/Conversation.kt
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable
 @JacksonDataClass
 data class Conversation(
         @JsonProperty("id") val id: String,
-        @JsonProperty("name") val name: String,
+        @JsonProperty("name") val name: String?,
         @JsonProperty("is_channel") val isChannel: Boolean,
         @JsonProperty("is_group") val isGroup: Boolean,
         @JsonProperty("is_im") val isIm: Boolean,


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## What problem are you trying to solve or corresponding Issue
<!--- Tell us what problem this improvement will solve or which issue it resolves -->
The name-property in the Conversation DTO is not needed everywhere

## Current Behavior
<!--- Tell us what happens instead of the expected behavior -->
conversations.list fails when the type is set to IM

## Improvement/New Behavior
<!--- Provide a detailed description of the change or addition you are proposing -->
fixes #235 