### PR TITLE
extended conversation dto, added extensions

### DIFF
--- a/data/slack-jackson-dto-test-extensions/src/main/kotlin/io/olaph/slack/dto/jackson/common/types/ConversationExtension.kt
+++ b/data/slack-jackson-dto-test-extensions/src/main/kotlin/io/olaph/slack/dto/jackson/common/types/ConversationExtension.kt
@@ -1,0 +1,46 @@
+package io.olaph.slack.dto.jackson.common.types
+
+fun Conversation.Companion.sample() = Conversation(
+        id = "",
+        name = "",
+        isChannel = true,
+        isGroup = false,
+        isIm = false,
+        created = 1449252889,
+        createdBy = "",
+        isArchived = false,
+        isGeneral = true,
+        unlinked = 0,
+        nameNormalized = "",
+        isReadOnly = false,
+        isShared = false,
+        isExtShared = false,
+        isOrgShared = false,
+        sharedTeamIds = listOf(),
+        pendingShared = listOf(),
+        isPendingExtShared = false,
+        isMember = true,
+        isPrivate = false,
+        isMpim = false,
+        topic = Conversation.Topic.sample(),
+        purpose = Conversation.Purpose.sample(),
+        previousNames = listOf(),
+        numMembers = 30,
+        lastRead = "",
+        isOpen = true,
+        priority = 1,
+        user = "",
+        isUserDeleted = false
+)
+
+fun Conversation.Topic.Companion.sample() = Conversation.Topic(
+        value = "",
+        createdBy = "",
+        lastSet = 1
+)
+
+fun Conversation.Purpose.Companion.sample() = Conversation.Purpose(
+        value = "",
+        createdBy = "",
+        lastSet = 1
+)

--- a/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/common/types/Conversation.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/io/olaph/slack/dto/jackson/common/types/Conversation.kt
@@ -12,12 +12,13 @@ data class Conversation(
         @JsonProperty("is_group") val isGroup: Boolean?,
         @JsonProperty("is_im") val isIm: Boolean?,
         @JsonProperty("created") val created: Int?,
+        @JsonProperty("creator") val createdBy: String?,
         @JsonProperty("is_archived") val isArchived: Boolean?,
         @JsonProperty("is_general") val isGeneral: Boolean?,
         @JsonProperty("unlinked") val unlinked: Int?,
         @JsonProperty("name_normalized") val nameNormalized: String?,
         @JsonProperty("is_shared") val isShared: Boolean?,
-        @JsonProperty("creator") val createdBy: String?,
+        @JsonProperty("is_read_only") val isReadOnly: Boolean?,
         @JsonProperty("is_ext_shared") val isExtShared: Boolean?,
         @JsonProperty("is_org_shared") val isOrgShared: Boolean?,
         @JsonProperty("shared_team_ids") val sharedTeamIds: List<String>?,
@@ -43,14 +44,18 @@ data class Conversation(
             @JsonProperty("value") val value: String,
             @JsonProperty("creator") val createdBy: String,
             @JsonProperty("last_set") val lastSet: Int
-    )
+    ) {
+        companion object
+    }
 
     @JacksonDataClass
     data class Topic(
             @JsonProperty("value") val value: String,
             @JsonProperty("creator") val createdBy: String,
             @JsonProperty("last_set") val lastSet: Int
-    )
+    ) {
+        companion object
+    }
 }
 
 


### PR DESCRIPTION
## Current Behavior
<!--- Tell us what happens instead of the expected behavior -->
Missing sample()-Methods for Conversation, Topic and Purpose DTO

## Improvement/New Behavior
- added missing "is_read_only" field to Conversation DTO
- created extension methods for Conversation, Topic and Purpose

closes #236 