### PR TITLE
Added blocks to Attachment-DTO

### DIFF
--- a/data/slack-jackson-dto-test-extensions/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/AttachmentExtensions.kt
+++ b/data/slack-jackson-dto-test-extensions/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/AttachmentExtensions.kt
@@ -1,3 +1,3 @@
 package com.kreait.slack.api.contract.jackson.common.messaging
 
-fun Attachment.Companion.sample(): Attachment = Attachment(fallback = "")
+fun Attachment.Companion.sample(): Attachment = Attachment(fallback = "", blocks = listOf())

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/Attachment.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/Attachment.kt
@@ -109,4 +109,4 @@ data class UpdateAttachment(
         @JsonProperty("actions") val actions: List<Action>? = listOf(),
         @JsonProperty("author_name") val authorName: String? = null,
         @JsonProperty("fallback") val fallback: String,
-        @JsonProperty("blocks") val blocks: List<Block>?)
+        @JsonProperty("blocks") val blocks: List<Block>? = null)

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/Attachment.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/Attachment.kt
@@ -39,7 +39,7 @@ data class Attachment(
         @JsonProperty("actions") val actions: List<Action>? = listOf(),
         @JsonProperty("text") val text: String? = null,
         @JsonProperty("author_name") val authorName: String? = null,
-        @JsonProperty("blocks") val blocks: List<Block>?) {
+        @JsonProperty("blocks") val blocks: List<Block>? = null) {
     companion object
 }
 

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/Attachment.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/messaging/Attachment.kt
@@ -38,7 +38,8 @@ data class Attachment(
         @JsonProperty("callback_id") val callbackId: String? = null,
         @JsonProperty("actions") val actions: List<Action>? = listOf(),
         @JsonProperty("text") val text: String? = null,
-        @JsonProperty("author_name") val authorName: String? = null) {
+        @JsonProperty("author_name") val authorName: String? = null,
+        @JsonProperty("blocks") val blocks: List<Block>?) {
     companion object
 }
 
@@ -107,4 +108,5 @@ data class UpdateAttachment(
         @JsonProperty("callback_id") val callbackId: String? = null,
         @JsonProperty("actions") val actions: List<Action>? = listOf(),
         @JsonProperty("author_name") val authorName: String? = null,
-        @JsonProperty("fallback") val fallback: String)
+        @JsonProperty("fallback") val fallback: String,
+        @JsonProperty("blocks") val blocks: List<Block>?)


### PR DESCRIPTION
As stated [here](https://api.slack.com/changelog/2018-12-a-bric-a-brac-of-broadcasts-built-with-blocks#block-preview) Blocks can not only be declared at top-level but also within an Attachment.

## Improvement/New Behavior
Added blocks-field to Attachment-DTO