### PR TITLE
Kdoc

### DIFF
--- a/client/slack-spring-api-client/src/main/kotlin/com/kreait/slack/api/spring/group/auth/DefaultRevokeMethod.kt
+++ b/client/slack-spring-api-client/src/main/kotlin/com/kreait/slack/api/spring/group/auth/DefaultRevokeMethod.kt
@@ -4,6 +4,7 @@ package com.kreait.slack.api.spring.group.auth
 import com.kreait.slack.api.contract.jackson.group.auth.ErrorAuthRevokeResponse
 import com.kreait.slack.api.contract.jackson.group.auth.AuthRevokeResponse
 import com.kreait.slack.api.contract.jackson.group.auth.SuccessfulAuthRevokeResponse
+import com.kreait.slack.api.contract.jackson.group.chat.ParseType
 import com.kreait.slack.api.group.ApiCallResult
 import com.kreait.slack.api.group.auth.AuthRevokeMethod
 import com.kreait.slack.api.spring.group.RestTemplateFactory
@@ -19,7 +20,6 @@ class DefaultRevokeMethod(private val authToken: String, private val restTemplat
                 .toMethod("auth.revoke")
                 .returnAsType(AuthRevokeResponse::class.java)
                 .postUrlEncoded(this.params.toRequestMap())
-
         return when (response.body!!) {
             is SuccessfulAuthRevokeResponse -> {
                 val responseEntity = response.body as SuccessfulAuthRevokeResponse

--- a/client/slack-spring-api-client/src/main/kotlin/com/kreait/slack/api/spring/group/groups/DefaultGroupsListMethod.kt
+++ b/client/slack-spring-api-client/src/main/kotlin/com/kreait/slack/api/spring/group/groups/DefaultGroupsListMethod.kt
@@ -9,6 +9,8 @@ import com.kreait.slack.api.spring.group.RestTemplateFactory
 import com.kreait.slack.api.spring.group.SlackRequestBuilder
 import org.springframework.web.client.RestTemplate
 
+
+@Deprecated("Don't use this legacy method", replaceWith = ReplaceWith("conversations.list"))
 class DefaultGroupsListMethod(private val authToken: String, private val restTemplate: RestTemplate = RestTemplateFactory.slackTemplate()) : GroupsListMethod() {
 
     override fun request(): ApiCallResult<SuccessfulGroupsListResponse, ErrorGroupsListResponse> {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/ResponseMetadata.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/common/ResponseMetadata.kt
@@ -3,6 +3,13 @@ package com.kreait.slack.api.contract.jackson.common
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
+
+/**
+ * Metadata for responses
+ *
+ * @property nextCursor parameter used for paging
+ * @property warnings warnings retreived by the api
+ */
 @JacksonDataClass
 data class ResponseMetadata(@JsonProperty("next_cursor") val nextCursor: String? = null,
                             @JsonProperty("warnings") val warnings: List<String>? = null) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/auth/Revoke.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/auth/Revoke.kt
@@ -17,6 +17,12 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class AuthRevokeResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property isRevoked true if token was revoked
+ */
 @JacksonDataClass
 data class SuccessfulAuthRevokeResponse constructor(
         override val ok: Boolean,
@@ -25,6 +31,12 @@ data class SuccessfulAuthRevokeResponse constructor(
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorAuthRevokeResponse constructor(
         override val ok: Boolean,
@@ -34,6 +46,12 @@ data class ErrorAuthRevokeResponse constructor(
 }
 
 
+/**
+ * Revokes a token.
+ *
+ * @property test setting test = true triggers a testing mode where the specified token will not actually be revoked
+ * @see [Slack Api Method](https://api.slack.com/methods/auth.revoke)
+ */
 data class AuthRevokeRequest constructor(private val test: Boolean?) {
 
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/auth/Test.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/auth/Test.kt
@@ -17,6 +17,16 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class AuthTestResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property url url to the slack-workspace
+ * @property team the team-name in which the requesting user is
+ * @property user the username of the requesting user
+ * @property teamId the teamId in which the requesting user is
+ * @property userId the user-id of the requesting user
+ */
 @JacksonDataClass
 data class SuccessfulAuthTestResponse constructor(
         override val ok: Boolean,
@@ -29,6 +39,13 @@ data class SuccessfulAuthTestResponse constructor(
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ * @see [Slack Api Method](https://api.slack.com/methods/auth.test)
+ */
 @JacksonDataClass
 data class ErrorAuthTestResponse constructor(
         override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Archive.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Archive.kt
@@ -18,12 +18,24 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ChannelArchiveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulChannelArchiveResponse constructor(override val ok: Boolean)
     : ChannelArchiveResponse(ok) {
     companion object
 }
 
+
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelArchiveResponse constructor(override val ok: Boolean,
                                                    @JsonProperty("error") val error: String)
@@ -31,6 +43,12 @@ data class ErrorChannelArchiveResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Archives a channel.
+ *
+ * @property channel the channel-id you want to archive
+ * @see [Slack Api Method](https://api.slack.com/methods/channels.archive)
+ */
 @JacksonDataClass
 data class ChannelsArchiveRequest constructor(@JsonProperty("channel") val channel: String) {
 

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Create.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Create.kt
@@ -19,6 +19,12 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ChannelsCreateResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the channel object that was created
+ */
 @JacksonDataClass
 data class SuccessfulChannelsCreateResponse constructor(override val ok: Boolean,
                                                         @JsonProperty("channel") val channel: Channel)
@@ -26,6 +32,12 @@ data class SuccessfulChannelsCreateResponse constructor(override val ok: Boolean
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsCreateResponse constructor(override val ok: Boolean,
                                                    @JsonProperty("error") val error: String,
@@ -35,6 +47,13 @@ data class ErrorChannelsCreateResponse constructor(override val ok: Boolean,
 }
 
 
+/**
+ * Creates a channel.
+ *
+ * @property name the name of the channel you want to create
+ * @property validate Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+ * @see [Slack Api Method](https://api.slack.com/methods/channels.create)
+ */
 @JacksonDataClass
 data class ChannelsCreateRequest constructor(@JsonProperty("name") val name: String,
                                              @JsonProperty("validate") val validate: Boolean?) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/History.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/History.kt
@@ -18,6 +18,14 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ChannelsHistoryResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property messages list of history-messages
+ * @property latestTimestamp timestamp of the latest message
+ * @property hasMore boolean that determines if more messages are available
+ */
 @JacksonDataClass
 data class SuccessfulChannelsHistoryResponse constructor(override val ok: Boolean,
                                                          @JsonProperty("messages") val messages: List<Message>?,
@@ -59,6 +67,12 @@ data class SuccessfulChannelsHistoryResponse constructor(override val ok: Boolea
 }
 
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsHistoryResponse constructor(override val ok: Boolean,
                                                     @JsonProperty("error") val error: String)
@@ -67,6 +81,17 @@ data class ErrorChannelsHistoryResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Fetches history of messages and events from a channel.
+ *
+ * @property channelId Channel to fetch history for.
+ * @property count Number of messages to return, between 1 and 1000.
+ * @property inclusive Include messages with latest or oldest timestamp in results.
+ * @property latestTimestamp End of time range of messages to include in results.
+ * @property oldestTimestamp Start of time range of messages to include in results.
+ * @property unreads true if the response should contain unread_count_display
+ * @see [Slack Api Method](https://api.slack.com/methods/channels.history)
+ */
 @JacksonDataClass
 data class ChannelsHistoryRequest constructor(@JsonProperty("channel") val channelId: String,
                                               @JsonProperty("count") val count: Int? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Info.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Info.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.channels
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.types.Channel
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -17,6 +17,13 @@ import com.kreait.slack.api.contract.jackson.common.types.Channel
 @JacksonDataClass
 sealed class ChannelInfoResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the channel object with all information
+ */
 @JacksonDataClass
 data class SuccessfulChannelInfoResponse constructor(override val ok: Boolean,
                                                      @JsonProperty("channel") val channel: Channel)
@@ -25,6 +32,12 @@ data class SuccessfulChannelInfoResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelInfoResponse constructor(override val ok: Boolean,
                                                 @JsonProperty("error") val error: String)
@@ -33,6 +46,14 @@ data class ErrorChannelInfoResponse constructor(override val ok: Boolean,
     companion object
 }
 
+
+/**
+ * Gets information about a channel.
+ *
+ * @property channel Channel to get info on
+ * @property includeLocale Set this to true to receive the locale for this channel. Defaults to false
+ * @see [Slack Api Method](https://api.slack.com/methods/channels.info)
+ * */
 @JacksonDataClass
 data class ChannelsInfoRequest constructor(@JsonProperty("channel") val channel: String,
                                            @JsonProperty("include_locale") val includeLocale: Boolean = false) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Invite.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Invite.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.channels
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.types.Channel
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -19,6 +19,12 @@ import com.kreait.slack.api.contract.jackson.common.types.Channel
 @JacksonDataClass
 sealed class ChannelInviteResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-Response of this request
+ *
+ * @property ok will be true
+ * @property channel the channel in which the user was added
+ */
 @JacksonDataClass
 data class SuccessfulChannelInviteResponse constructor(override val ok: Boolean,
                                                        @JsonProperty("channel") val channel: Channel)
@@ -26,6 +32,12 @@ data class SuccessfulChannelInviteResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelInviteResponse constructor(override val ok: Boolean,
                                                   @JsonProperty("error") val error: String)
@@ -33,7 +45,13 @@ data class ErrorChannelInviteResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Invites a Users to a Channel
+ *
+ * @property channel the channel in which the user should be invited to
+ * @property user the user that should be invited to the channel
+ * @see
+ */
 @JacksonDataClass
 data class ChannelInviteRequest constructor(@JsonProperty("channel") val channel: String,
                                             @JsonProperty("user") val user: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Join.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Join.kt
@@ -17,6 +17,13 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ChannelsJoinResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the channel object which the user joined
+ * @property alreadyInChannel true if the user was already in the channel
+ */
 @JacksonDataClass
 data class SuccessfulChannelsJoinResponse constructor(override val ok: Boolean,
                                                       @JsonProperty("channel") val channel: Channel,
@@ -26,6 +33,12 @@ data class SuccessfulChannelsJoinResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsJoinResponse constructor(override val ok: Boolean,
                                                  @JsonProperty("error") val error: String)
@@ -33,6 +46,13 @@ data class ErrorChannelsJoinResponse constructor(override val ok: Boolean,
 
     companion object
 }
+
+/**
+ * Joins a channel, creating it if needed.
+ *
+ * @property name Name of channel to join
+ * @property validate Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+ */
 
 @JacksonDataClass
 data class ChannelsJoinRequest constructor(@JsonProperty("name") val name: String,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Kick.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Kick.kt
@@ -16,6 +16,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ChannelKickResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulChannelKickResponse constructor(override val ok: Boolean)
     : ChannelKickResponse(ok) {
@@ -23,6 +28,12 @@ data class SuccessfulChannelKickResponse constructor(override val ok: Boolean)
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelKickResponse constructor(override val ok: Boolean,
                                                 @JsonProperty("error") val error: String)
@@ -31,6 +42,12 @@ data class ErrorChannelKickResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Removes a user from a channel.
+ *
+ * @property channelId the channel-id from which the user should be removed
+ * @property userId the user-id that should be removed
+ */
 @JacksonDataClass
 data class ChannelsKickRequest constructor(@JsonProperty("channel") val channelId: String,
                                            @JsonProperty("user") val userId: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Leave.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Leave.kt
@@ -15,6 +15,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
         JsonSubTypes.Type(value = ErrorChannelsLeaveResponse::class, name = "false")
 )
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 sealed class ChannelsLeaveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
@@ -24,6 +29,12 @@ data class SuccessfulChannelsLeaveResponse constructor(override val ok: Boolean)
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsLeaveResponse constructor(override val ok: Boolean,
                                                   @JsonProperty("error") val error: String,
@@ -32,7 +43,11 @@ data class ErrorChannelsLeaveResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Leaves a channel
+ *
+ * @property channelId id of the channel you want to leave
+ */
 @JacksonDataClass
 data class ChannelsLeaveRequest constructor(@JsonProperty("channel") val channelId: String) {
 

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Mark.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Mark.kt
@@ -17,6 +17,11 @@ import java.time.Instant
         JsonSubTypes.Type(value = ErrorChannelsMarkResponse::class, name = "false")
 )
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 sealed class ChannelsMarkResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
@@ -26,6 +31,12 @@ data class SuccessfulChannelsMarkResponse constructor(override val ok: Boolean)
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsMarkResponse constructor(override val ok: Boolean,
                                                  @JsonProperty("error") val error: String,
@@ -34,7 +45,12 @@ data class ErrorChannelsMarkResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Sets the read cursor in a channel.
+ *
+ * @property channelId the channel-id on which the read cursor should be set
+ * @property timestamp Timestamp of the most recently seen message.
+ */
 @JacksonDataClass
 data class ChannelsMarkRequest constructor(@JsonProperty("channel") val channelId: String,
                                            @InstantToString @JsonProperty("ts") val timestamp: Instant) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Rename.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Rename.kt
@@ -10,15 +10,18 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
         include = JsonTypeInfo.As.PROPERTY,
         property = "ok",
         visible = true)
-
 @JsonSubTypes(
         JsonSubTypes.Type(value = SuccessfulChannelRenameResponse::class, name = "true"),
-        JsonSubTypes.Type(value = ErrorChannelRenameResponse::class, name = "false")
-)
-
+        JsonSubTypes.Type(value = ErrorChannelRenameResponse::class, name = "false"))
 @JacksonDataClass
 sealed class ChannelRenameResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the channel object of the renamed channel
+ */
 @JacksonDataClass
 data class SuccessfulChannelRenameResponse constructor(override val ok: Boolean,
                                                        @JsonProperty("channel") val channel: Channel)
@@ -26,6 +29,12 @@ data class SuccessfulChannelRenameResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelRenameResponse constructor(override val ok: Boolean,
                                                   @JsonProperty("error") val error: String)
@@ -33,7 +42,13 @@ data class ErrorChannelRenameResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Renames a channel.
+ *
+ * @property channelId the channel-id of the channel you want to rename
+ * @property name the new channel-name
+ * @property validate Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+ */
 @JacksonDataClass
 data class ChannelRenameRequest constructor(@JsonProperty("channel") val channelId: String,
                                             @JsonProperty("name") val name: String,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Replies.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Replies.kt
@@ -20,9 +20,16 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ChannelsRepliesResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property messages the messages of the thread
+ * @property hasMore determines if more messages exist
+ */
 @JacksonDataClass
 data class SuccessfulChannelsRepliesResponse constructor(override val ok: Boolean,
-                                                         @JsonProperty("messages") val channel: List<Message>,
+                                                         @JsonProperty("messages") val messages: List<Message>,
                                                          @JsonProperty("has_more") val hasMore: Boolean = false)
     : ChannelsRepliesResponse(ok) {
     companion object {}
@@ -53,7 +60,12 @@ data class SuccessfulChannelsRepliesResponse constructor(override val ok: Boolea
     }
 }
 
-
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsRepliesResponse constructor(override val ok: Boolean,
                                                     @JsonProperty("error") val error: String,
@@ -62,7 +74,12 @@ data class ErrorChannelsRepliesResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Retrieve a thread of messages posted to a channel
+ *
+ * @property channelId Channel to fetch thread from
+ * @property threadTimestamp Unique identifier of a thread's parent message
+ */
 @JacksonDataClass
 data class ChannelsRepliesRequest constructor(@JsonProperty("channel") val channelId: String,
                                               @InstantToString @JsonProperty("thread_ts") val threadTimestamp: Instant) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/SetPurpose.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/SetPurpose.kt
@@ -18,6 +18,12 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ChannelsSetPurposeResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property purpose the purpose you set
+ */
 @JacksonDataClass
 data class SuccessfulChannelsSetPurposeResponse constructor(override val ok: Boolean,
                                                             @JsonProperty("purpose") val purpose: String)
@@ -25,6 +31,12 @@ data class SuccessfulChannelsSetPurposeResponse constructor(override val ok: Boo
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsSetPurposeResponse constructor(override val ok: Boolean,
                                                        @JsonProperty("error") val error: String)
@@ -32,7 +44,13 @@ data class ErrorChannelsSetPurposeResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Sets the purpose for a channel.
+ *
+ * @property channel the channelId of which you want to set the purpose
+ * @property purpose the purpose you want to set
+ * @property nameTagging true if names and mentions should be resolved
+ */
 @JacksonDataClass
 data class ChannelsSetPurposeRequest constructor(@JsonProperty("channel") val channel: String,
                                                  @JsonProperty("purpose") val purpose: String,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/SetTopic.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/SetTopic.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.channels
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.types.Channel
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -19,6 +19,12 @@ import com.kreait.slack.api.contract.jackson.common.types.Channel
 @JacksonDataClass
 sealed class ChannelsSetTopicResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the channel object with the changed topic
+ */
 @JacksonDataClass
 data class SuccessfulChannelsSetTopicResponse constructor(override val ok: Boolean,
                                                           @JsonProperty("channel") val channel: Channel)
@@ -26,6 +32,12 @@ data class SuccessfulChannelsSetTopicResponse constructor(override val ok: Boole
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelsSetTopicResponse constructor(override val ok: Boolean,
                                                      @JsonProperty("error") val error: String,
@@ -34,7 +46,12 @@ data class ErrorChannelsSetTopicResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Sets the topic for a channel.
+ *
+ * @property channelId Channel to set the topic of
+ * @property topic the topic you want to set
+ */
 @JacksonDataClass
 data class ChannelsSetTopicRequest constructor(@JsonProperty("channel") val channelId: String,
                                                @JsonProperty("topic") val topic: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Unarchive.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/channels/Unarchive.kt
@@ -18,12 +18,23 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ChannelUnarchiveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulChannelUnarchiveResponse constructor(override val ok: Boolean)
     : ChannelUnarchiveResponse(ok) {
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChannelUnarchiveResponse constructor(override val ok: Boolean,
                                                      @JsonProperty("error") val error: String)
@@ -31,6 +42,11 @@ data class ErrorChannelUnarchiveResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Unarchives a channel.
+ *
+ * @property channelId the channel-id you want to unarchive
+ */
 @JacksonDataClass
 data class ChannelsUnarchiveRequest constructor(@JsonProperty("channel") val channelId: String) {
 

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/Delete.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/Delete.kt
@@ -18,6 +18,13 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ChatDeleteResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the channel-id of the channel in which the message was in
+ * @property timestamp the timestamp of the deleted message
+ */
 @JacksonDataClass
 data class SuccessfulChatDeleteResponse constructor(override val ok: Boolean,
                                                     @JsonProperty("channel") val channel: String,
@@ -27,6 +34,12 @@ data class SuccessfulChatDeleteResponse constructor(override val ok: Boolean,
 }
 
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChatDeleteResponse constructor(override val ok: Boolean,
                                                @JsonProperty("error") val error: String)
@@ -34,7 +47,13 @@ data class ErrorChatDeleteResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Deletes a Message in a Chat
+ *
+ * @property channel the channel-id you want to delete
+ * @property timestamp Timestamp of the message to be deleted.
+ * @property asUser Pass true to delete the message as the authed user with chat:write:user scope. Bot users in this context are considered authed users. If unused or false, the message will be deleted with chat:write:bot scope.
+ */
 @JacksonDataClass
 data class ChatDeleteRequest constructor(@JsonProperty("channel") val channel: String,
                                          @InstantToString @JsonProperty("ts") val timestamp: Instant,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/GetPermalink.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/GetPermalink.kt
@@ -7,12 +7,6 @@ import com.kreait.slack.api.contract.jackson.util.InstantToString
 import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import java.time.Instant
 
-@JacksonDataClass
-data class ChatGetPermalinkRequest constructor(@JsonProperty("channel") val channel: String,
-                                               @InstantToString @JsonProperty("message_ts") val timestamp: Instant) {
-    companion object
-}
-
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
         property = "ok",
@@ -24,6 +18,13 @@ data class ChatGetPermalinkRequest constructor(@JsonProperty("channel") val chan
 @JacksonDataClass
 sealed class ChatGetPermalinkResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channelId the channel-id of the message
+ * @property permalink the requested permalink
+ */
 @JacksonDataClass
 data class SuccessfulChatGetPermalinkResponse constructor(override val ok: Boolean,
                                                           @JsonProperty("channel") val channelId: String,
@@ -31,6 +32,12 @@ data class SuccessfulChatGetPermalinkResponse constructor(override val ok: Boole
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChatGetPermalinkResponse constructor(override val ok: Boolean,
                                                      @JsonProperty("error") val error: String)
@@ -38,4 +45,14 @@ data class ErrorChatGetPermalinkResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Retrieve a permalink URL for a specific extant message
+ *
+ * @property channel the channel-id of the message
+ * @property timestamp the timestamp of the message
+ */
+@JacksonDataClass
+data class ChatGetPermalinkRequest constructor(@JsonProperty("channel") val channel: String,
+                                               @InstantToString @JsonProperty("message_ts") val timestamp: Instant) {
+    companion object
+}

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/MeMessage.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/MeMessage.kt
@@ -18,6 +18,11 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ChatMeMessageResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulChatMeMessageResponse constructor(override val ok: Boolean,
                                                        @JsonProperty("channel") val channelId: String,
@@ -27,6 +32,12 @@ data class SuccessfulChatMeMessageResponse constructor(override val ok: Boolean,
 }
 
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChatMeMessageResponse constructor(override val ok: Boolean,
                                                   @JsonProperty("error") val error: String)
@@ -34,7 +45,12 @@ data class ErrorChatMeMessageResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * Sends a me message to a channel from the calling user.
+ *
+ * @property channelId Channel to send message to. Can be a public channel, private group or IM channel. Can be an encoded ID, or a name.
+ * @property text The message-text
+ */
 @JacksonDataClass
 data class ChatMeMessageRequest constructor(@JsonProperty("channel") val channelId: String,
                                             @JsonProperty("text") val text: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/ParseType.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/ParseType.kt
@@ -9,10 +9,23 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
+/**
+ * They ParseType for messages
+ * @property value the valueString
+ * @see [Slack Formatting Guide](https://api.slack.com/docs/message-formatting)
+ */
 @JsonSerialize(using = ParseType.Serializer::class)
 @JsonDeserialize(using = ParseType.Deserializer::class)
 enum class ParseType(private val value: String) {
-    FULL("full"), NONE("none"), CLIENT("client");
+    /**
+     * will ignore any markup formatting you added to your message
+     */
+    FULL("full"),
+    /**
+     * If you want Slack to treat your message as completely unformatted, pass parse=full. This will ignore any markup formatting you added to your message.
+     */
+    NONE("none"),
+    CLIENT("client");
 
     class Serializer : JsonSerializer<ParseType>() {
         override fun serialize(parseType: ParseType, gen: JsonGenerator?, serializers: SerializerProvider?) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/PostEphemeral.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/PostEphemeral.kt
@@ -20,6 +20,12 @@ import java.time.Instant
 @JacksonDataClass
 sealed class PostEphemeralResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property messageTimestamp the message-timestamp of the posted message
+ */
 @JacksonDataClass
 data class SuccessfulPostEphemeralResponse constructor(override val ok: Boolean,
                                                        @InstantToString @JsonProperty("message_ts") val messageTimestamp: Instant)
@@ -27,6 +33,12 @@ data class SuccessfulPostEphemeralResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorPostEphemeralResponse constructor(override val ok: Boolean,
                                                   @JsonProperty("error") val error: String)
@@ -34,6 +46,20 @@ data class ErrorPostEphemeralResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Sends an ephemeral message to a user in a channel.
+ * Ephemeral Messages are not persisted in the database and can thus not be modified or deleted
+ *
+ * @property text the text of the message
+ * @property attachments secondary attachments
+ * @property blocks secondary block items
+ * @property channel the channel in which the ephemeral-message should be shown
+ * @property asUser Pass true to post the message as the authed user. Defaults to true if the chat:write:bot scope is not included. Otherwise, defaults to false.
+ * @property user the user-id that should receive the ephemeral message
+ * @property linkNames Find and link channel names and usernames.
+ * @property parse the parse-type for this message
+ * @property threadTimestamp Provide another message's ts value to post this message in a thread. Avoid using a reply's ts value; use its parent's value instead. Ephemeral messages in threads are only shown if there is already an active thread.
+ */
 @JacksonDataClass
 data class PostEphemeralRequest constructor(@JsonProperty("text") val text: String? = null,
                                             @JsonProperty("attachments") val attachments: List<Attachment>? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/PostMessage.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/PostMessage.kt
@@ -20,6 +20,14 @@ import java.time.Instant
 @JacksonDataClass
 sealed class PostMessageResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the channel in which the message was posted
+ * @property timestamp the timestamp of the posted message
+ * @property message the posted message
+ */
 @JacksonDataClass
 data class SuccessfulPostMessageResponse constructor(override val ok: Boolean,
                                                      @JsonProperty("channel") val channel: String,
@@ -41,12 +49,39 @@ data class Message(
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorPostMessageResponse constructor(override val ok: Boolean,
                                                 @JsonProperty("error") val error: String) : PostMessageResponse(ok) {
     companion object
 }
 
+/**
+ * Posts a public Message to a Channel
+ *
+ * @property text the text of the message
+ * @property channel the channel in which the message should be posted
+ * @property attachments secondary attachments of the message
+ * @property blocks secondary block items of the message
+ * @property asUser Pass true to post the message as the authed user, instead of as a bot. Defaults to false.
+ * @property username Set your bot's user name. Must be used in conjunction with as_user set to false, otherwise ignored.
+ * @property iconEmoji Emoji to use as the icon for this message. Overrides icon_url. Must be used in conjunction with as_user set to false, otherwise ignored. See authorship below.
+ * @property iconUrl URL to an image to use as the icon for this message. Must be used in conjunction with as_user set to false, otherwise ignored. See authorship below.
+ * @property linkNames Find and link channel names and usernames.
+ * @property markDown Disable Slack markup parsing by setting to false. Enabled by default.
+ * @property parse the parse-mode
+ * @property replyBroadcast Used in conjunction with thread_ts and indicates whether reply should be made visible to everyone in the channel or conversation. Defaults to false.
+ * @property threadTimestamp Provide another message's ts value to make this message a reply. Avoid using a reply's ts value; use its parent instead.
+ * @property unfurlLinks Pass true to enable unfurling of primarily text-based content.
+ * @property unfurlMedia Pass false to disable unfurling of media content.
+ *
+ * @see [Slack Authorship guide](https://api.slack.com/methods/chat.postMessage#authorship)
+ */
 @JacksonDataClass
 data class PostMessageRequest constructor(@JsonProperty("text") val text: String,
                                           @JsonProperty("channel") val channel: String,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/Unfurl.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/Unfurl.kt
@@ -18,6 +18,11 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ChatUnfurlResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulChatUnfurlResponse constructor(override val ok: Boolean)
     : ChatUnfurlResponse(ok) {
@@ -25,6 +30,12 @@ data class SuccessfulChatUnfurlResponse constructor(override val ok: Boolean)
 }
 
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChatUnfurlResponse constructor(override val ok: Boolean,
                                                @JsonProperty("error") val error: String)
@@ -32,7 +43,16 @@ data class ErrorChatUnfurlResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * This method attaches Slack app unfurl behavior to a specified and relevant message. A user token is required as this method does not support bot user tokens.
+ *
+ * @property channelId Channel ID of the message
+ * @property timestamp Timestamp of the message to add unfurl behavior to.
+ * @property unfurls URL-encoded JSON map with keys set to URLs featured in the the message, pointing to their unfurl blocks or message attachments.
+ * @property userAuthMessage Provide a simply-formatted string to send as an ephemeral message to the user as invitation to authenticate further and enable full unfurling behavior
+ * @property userAuthRequired Set to true or 1 to indicate the user must install your Slack app to trigger unfurls for this domain
+ * @property userAuthUrl Send users to this custom URL where they will complete authentication in your app to fully trigger unfurling. Value should be properly URL-encoded.
+ */
 @JacksonDataClass
 data class ChatUnfurlRequest constructor(@JsonProperty("channel") val channelId: String,
                                          @InstantToString @JsonProperty("ts") val timestamp: Instant,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/Update.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/chat/Update.kt
@@ -8,17 +8,6 @@ import com.kreait.slack.api.contract.jackson.util.InstantToString
 import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import java.time.Instant
 
-@JacksonDataClass
-data class ChatUpdateRequest constructor(@JsonProperty("channel") val channel: String,
-                                         @JsonProperty("text") val text: String? = null,
-                                         @InstantToString @JsonProperty("ts") val timestamp: Instant,
-                                         @JsonProperty("as_user") val asUser: Boolean? = true,
-                                         @JsonProperty("attachments") val attachments: List<UpdateAttachment>? = null,
-                                         @JsonProperty("link_names") val linkNames: Boolean? = true,
-                                         @JsonProperty("parse") val parse: ParseType? = null) {
-    companion object
-}
-
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
         property = "ok",
@@ -30,6 +19,11 @@ data class ChatUpdateRequest constructor(@JsonProperty("channel") val channel: S
 @JacksonDataClass
 sealed class ChatUpdateResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulChatUpdateResponse constructor(override val ok: Boolean,
                                                     @JsonProperty("channel") val channel: String,
@@ -39,6 +33,12 @@ data class SuccessfulChatUpdateResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorChatUpdateResponse constructor(override val ok: Boolean,
                                                @JsonProperty("error") val error: String)
@@ -46,4 +46,25 @@ data class ErrorChatUpdateResponse constructor(override val ok: Boolean,
     companion object
 }
 
-
+/**
+ * This method updates a message in a channel. Though related to chat.postMessage, some parameters of chat.update are handled differently.
+ * Ephemeral messages created by chat.postEphemeral or otherwise cannot be updated with this method.
+ *
+ * @property channel the channel-id in which the message exists
+ * @property text the new text of the message
+ * @property timestamp the timestamp of the message you want to update
+ * @property asUser Pass true to update the message as the authed user. Bot users in this context are considered authed users.
+ * @property attachments new attachments
+ * @property linkNames Find and link channel names and usernames. Defaults to none.
+ * @property parse the @link[ParseType] of that message
+ */
+@JacksonDataClass
+data class ChatUpdateRequest constructor(@JsonProperty("channel") val channel: String,
+                                         @JsonProperty("text") val text: String? = null,
+                                         @InstantToString @JsonProperty("ts") val timestamp: Instant,
+                                         @JsonProperty("as_user") val asUser: Boolean? = true,
+                                         @JsonProperty("attachments") val attachments: List<UpdateAttachment>? = null,
+                                         @JsonProperty("link_names") val linkNames: Boolean? = true,
+                                         @JsonProperty("parse") val parse: ParseType? = null) {
+    companion object
+}

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Archive.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Archive.kt
@@ -18,7 +18,9 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class ConversationArchiveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.archive)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationArchiveResponse(
         override val ok: Boolean) : ConversationArchiveResponse(ok) {
@@ -26,7 +28,10 @@ data class SuccessfulConversationArchiveResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.archive)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorConversationArchiveResponse constructor(
         override val ok: Boolean,
@@ -36,7 +41,9 @@ data class ErrorConversationArchiveResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.archive)
+ * This method archives a conversation. Not all types of conversations can be archived.
+ *
+ * @property channel the channel id you want to archive
  */
 data class ConversationArchiveRequest(@JsonProperty("channel") val channel: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Close.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Close.kt
@@ -21,6 +21,7 @@ sealed class ConversationCloseResponse constructor(@JsonProperty("ok") open val 
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property alreadyClosed true if the conversation was already closed
  */
 data class SuccessfulConversationCloseResponse(
         override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Close.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Close.kt
@@ -18,7 +18,9 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class ConversationCloseResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.close)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationCloseResponse(
         override val ok: Boolean,
@@ -29,7 +31,10 @@ data class SuccessfulConversationCloseResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.close)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorConversationCloseResponse constructor(
         override val ok: Boolean,
@@ -39,7 +44,9 @@ data class ErrorConversationCloseResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.close)
+ * Closes a direct message or multi-person direct message.
+ *
+ * @property channel the channel-id you want to close
  */
 data class ConversationCloseRequest(@JsonProperty("channel") val channel: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Create.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Create.kt
@@ -21,6 +21,7 @@ sealed class ConversationCreateResponse constructor(@JsonProperty("ok") open val
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property channel the new channel object you created
  */
 data class SuccessfulConversationCreateResponse(
         override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Create.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Create.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.conversations
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.types.Channel
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -18,7 +18,9 @@ import com.kreait.slack.api.contract.jackson.common.types.Channel
 sealed class ConversationCreateResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.create)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationCreateResponse(
         override val ok: Boolean,
@@ -28,7 +30,10 @@ data class SuccessfulConversationCreateResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.create)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 @JacksonDataClass
 data class ErrorConversationCreateResponse constructor(override val ok: Boolean,
@@ -38,7 +43,10 @@ data class ErrorConversationCreateResponse constructor(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.create)
+ * Initiates a public or private channel-based conversation
+ *
+ * @property name the channel name for the channel you want to create
+ * @property isPrivate true if you want to create a private channel
  */
 data class ConversationCreateRequest(@JsonProperty("name") val name: String,
                                      @JsonProperty("is_private") val isPrivate: Boolean? = null) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/History.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/History.kt
@@ -23,6 +23,10 @@ sealed class ConversationHistoryResponse constructor(@JsonProperty("ok") open va
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property messages the history-messages
+ * @property hasMore determines if more messages are available
+ * @property pinCount number of pinned messages
+ * @property responseMetadata additional information about the response
  */
 data class SuccessfulConversationHistoryResponse(
         override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/History.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/History.kt
@@ -3,9 +3,9 @@ package com.kreait.slack.api.contract.jackson.group.conversations
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.ResponseMetadata
 import com.kreait.slack.api.contract.jackson.util.InstantToString
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import java.time.Instant
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
@@ -19,6 +19,11 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ConversationHistoryResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 data class SuccessfulConversationHistoryResponse(
         override val ok: Boolean,
         @JsonProperty("messages") val messages: List<Message>,
@@ -29,6 +34,12 @@ data class SuccessfulConversationHistoryResponse(
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorConversationHistoryResponse constructor(override val ok: Boolean,
                                                         @JsonProperty("error") val error: String)
@@ -60,7 +71,14 @@ data class Message(
 
 
 /**
- * DataClass that represents arguments as defined here https://api.slack.com/methods/conversations.history
+ * Fetches a conversation's history of messages and events.
+ *
+ * @property channel The channel id you want to fetch messages from
+ * @property cursor Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first "page" of the collection.
+ * @property inclusive Include messages with latest or oldest timestamp in results only when either timestamp is specified.
+ * @property latest End of time range of messages to include in results.
+ * @property limit The maximum number of items to return.
+ * @property oldest Start of time range of messages to include in results.
  */
 data class ConversationsHistoryRequest(private val channel: String,
                                        private val cursor: String? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Info.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Info.kt
@@ -22,6 +22,7 @@ sealed class ConversationsInfoResponse constructor(@JsonProperty("ok") open val 
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property channel the channel information
  */
 @JacksonDataClass
 data class SuccessfulConversationsInfoResponse constructor(override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Info.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Info.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.conversations
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.types.Channel
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
@@ -18,6 +18,11 @@ import com.kreait.slack.api.contract.jackson.common.types.Channel
 @JacksonDataClass
 sealed class ConversationsInfoResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulConversationsInfoResponse constructor(override val ok: Boolean,
                                                            @JsonProperty("channel") val channel: Channel)
@@ -26,6 +31,12 @@ data class SuccessfulConversationsInfoResponse constructor(override val ok: Bool
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorConversationsInfoResponse constructor(override val ok: Boolean,
                                                       @JsonProperty("error") val error: String)
@@ -34,6 +45,14 @@ data class ErrorConversationsInfoResponse constructor(override val ok: Boolean,
     companion object
 }
 
+
+/**
+ * Retrieve information about a conversation.
+ *
+ * @property channel the channel-id you want to fetch information about
+ * @property includeLocale true if locale should be included in the response
+ * @property includeNumMembers Set to true to include the member count for the specified conversation.
+ */
 @JacksonDataClass
 data class ConversationsInfoRequest constructor(@JsonProperty("channel") val channel: String,
                                                 @JsonProperty("include_locale") val includeLocale: Boolean = false,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Invite.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Invite.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.conversations
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.types.Channel
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -18,7 +18,9 @@ import com.kreait.slack.api.contract.jackson.common.types.Channel
 sealed class ConversationInviteResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.invite)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 @JacksonDataClass
 data class SuccessfulConversationInviteResponse(
@@ -29,7 +31,10 @@ data class SuccessfulConversationInviteResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.invite)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 @JacksonDataClass
 data class ErrorConversationInviteResponse constructor(override val ok: Boolean,
@@ -39,7 +44,10 @@ data class ErrorConversationInviteResponse constructor(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.invite)
+ * Adds a user to the Conversation
+ *
+ * @property channel the channel-id you want to add the user to
+ * @property users the user-id which you want to add to the channel
  */
 data class ConversationsInviteRequest(@JsonProperty("channel") val channel: String,
                                       @JsonProperty("users") val users: List<String>) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Invite.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Invite.kt
@@ -21,6 +21,7 @@ sealed class ConversationInviteResponse constructor(@JsonProperty("ok") open val
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property channel the channel after adding the user
  */
 @JacksonDataClass
 data class SuccessfulConversationInviteResponse(

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Join.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Join.kt
@@ -22,6 +22,9 @@ sealed class ConversationJoinResponse(@JsonProperty("ok") open val ok: Boolean)
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property channel the channel-object after joining it
+ * @property warning additional non-fatal warnings
+ * @property responseMetadata responseMetadata, used for paging
  */
 data class SuccessfulConversationJoinResponse(override val ok: Boolean,
                                               @JsonProperty("channel") val channel: Channel,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Join.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Join.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.conversations
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.ResponseMetadata
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -19,7 +19,9 @@ import com.kreait.slack.api.contract.jackson.common.ResponseMetadata
 sealed class ConversationJoinResponse(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.join)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationJoinResponse(override val ok: Boolean,
                                               @JsonProperty("channel") val channel: Channel,
@@ -36,7 +38,10 @@ data class SuccessfulConversationJoinResponse(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.join)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 @JacksonDataClass
 data class ErrorConversationJoinResponse constructor(override val ok: Boolean,
@@ -46,7 +51,9 @@ data class ErrorConversationJoinResponse constructor(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.join)
+ * Joins a channel
+ *
+ * @property channel the channel-id you want to join
  */
 data class ConversationJoinRequest(@JsonProperty("channel") val channel: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Kick.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Kick.kt
@@ -17,7 +17,9 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class ConversationsKickResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.kick)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationKickResponse(
         override val ok: Boolean) : ConversationsKickResponse(ok) {
@@ -25,17 +27,23 @@ data class SuccessfulConversationKickResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.kick)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 @JacksonDataClass
 data class ErrorConversationKickResponse constructor(override val ok: Boolean,
-                                                      @JsonProperty("error") val error: String)
+                                                     @JsonProperty("error") val error: String)
     : ConversationsKickResponse(ok) {
     companion object
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.kick)
+ * Removes a user from a conversation
+ *
+ * @property channel the channel-id of the channel you want to remove the user from
+ * @property user the user-id of the user you want to remove
  */
 data class ConversationsKickRequest(@JsonProperty("channel") val channel: String,
                                     @JsonProperty("user") val user: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Leave.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Leave.kt
@@ -17,7 +17,9 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class ConversationsLeaveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.leave)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationLeaveResponse(
         override val ok: Boolean,
@@ -26,7 +28,10 @@ data class SuccessfulConversationLeaveResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.leave)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 @JacksonDataClass
 data class ErrorConversationLeaveResponse constructor(override val ok: Boolean,
@@ -36,7 +41,9 @@ data class ErrorConversationLeaveResponse constructor(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.leave)
+ * Leaves a conversation
+ *
+ * @property channel the channelId of the channel you want to leve
  */
 data class ConversationsLeaveRequest(@JsonProperty("channel") val channel: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/List.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/List.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.kreait.slack.api.contract.jackson.ChannelType
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.ResponseMetadata
 import com.kreait.slack.api.contract.jackson.common.types.Conversation
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -19,6 +19,11 @@ import com.kreait.slack.api.contract.jackson.common.types.Conversation
 @JacksonDataClass
 sealed class ConversationListResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 data class SuccessfulConversationListResponse(
         override val ok: Boolean,
         @JsonProperty("channels") val channels: List<Conversation>,
@@ -35,7 +40,12 @@ data class ErrorConversationListResponse constructor(override val ok: Boolean,
 }
 
 /**
- * DataClass that represents arguments as defined here https://api.slack.com/methods/conversations.list
+ * Lists all channels
+ *
+ * @property cursor Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first "page" of the collection.
+ * @property excludeArchived Set to true to exclude archived channels from the list
+ * @property limit The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached. Must be an integer no larger than 1000.
+ * @property Mix and match channel types by providing a comma-separated list of any combination of public_channel, private_channel, mpim, im
  */
 data class ConversationsListRequest(private val cursor: String? = null,
                                     private val excludeArchived: Boolean? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Members.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Members.kt
@@ -3,8 +3,8 @@ package com.kreait.slack.api.contract.jackson.group.conversations
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.ResponseMetadata
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
@@ -18,6 +18,11 @@ import com.kreait.slack.api.contract.jackson.common.ResponseMetadata
 @JacksonDataClass
 sealed class ConversationMembersResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulConversationMembersResponse constructor(override val ok: Boolean,
                                                              @JsonProperty("members") val memberIds: List<String>,
@@ -26,6 +31,12 @@ data class SuccessfulConversationMembersResponse constructor(override val ok: Bo
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorConversationMembersResponse constructor(override val ok: Boolean, @JsonProperty("error") val error: String)
     : ConversationMembersResponse(ok) {
@@ -33,7 +44,11 @@ data class ErrorConversationMembersResponse constructor(override val ok: Boolean
 }
 
 /**
- * DataClass that represents arguments as defined here https://api.slack.com/methods/conversations.members
+ * Retrieve members of a conversation.
+ *
+ * @property channelId channel-id of the channel you want to fetch the users from
+ * @property cursor Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first "page" of the collection.
+ * @property limit The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.
  */
 data class ConversationMembersRequest(private val channelId: String,
                                       private val cursor: String? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Members.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Members.kt
@@ -22,6 +22,8 @@ sealed class ConversationMembersResponse constructor(@JsonProperty("ok") open va
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property memberIds the member-ids of the channel
+ * @property responseMetadata metadata used for paging
  */
 @JacksonDataClass
 data class SuccessfulConversationMembersResponse constructor(override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Open.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Open.kt
@@ -18,6 +18,11 @@ sealed class ConversationOpenResponse constructor(@JsonProperty("ok") open val o
     companion object
 }
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulConversationOpenResponse constructor(override val ok: Boolean,
                                                           @JsonProperty("channel") val channel: Channel)
@@ -32,12 +37,25 @@ data class SuccessfulConversationOpenResponse constructor(override val ok: Boole
     }
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorConversationOpenResponse constructor(override val ok: Boolean, @JsonProperty("error") val error: String)
     : ConversationOpenResponse(ok) {
     companion object
 }
 
+/**
+ * Opens or resumes a direct message or multi-person direct message.
+ *
+ * @property channelId Resume a conversation by supplying an im or mpim's ID. Or provide the users field instead.
+ * @property shouldReturnIm Boolean, indicates you want the full IM channel definition in the response.
+ * @property users Comma separated lists of users. If only one user is included, this creates a 1:1 DM. The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a channel when not supplying users.
+ */
 @JacksonDataClass
 data class ConversationsOpenRequest constructor(@JsonProperty("channel") val channelId: String? = null,
                                                 @JsonProperty("return_im") val shouldReturnIm: Boolean? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Open.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Open.kt
@@ -22,6 +22,7 @@ sealed class ConversationOpenResponse constructor(@JsonProperty("ok") open val o
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property channel the new channel object
  */
 @JacksonDataClass
 data class SuccessfulConversationOpenResponse constructor(override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Rename.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Rename.kt
@@ -22,6 +22,7 @@ sealed class ConversationsRenameResponse constructor(@JsonProperty("ok") open va
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property channel the renamed channel object
  */
 data class SuccessfulConversationsRenameResponse(
         override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Rename.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Rename.kt
@@ -3,9 +3,9 @@ package com.kreait.slack.api.contract.jackson.group.conversations
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 import com.kreait.slack.api.contract.jackson.common.ResponseMetadata
 import com.kreait.slack.api.contract.jackson.common.types.Channel
+import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
@@ -19,7 +19,9 @@ import com.kreait.slack.api.contract.jackson.common.types.Channel
 sealed class ConversationsRenameResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.rename)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationsRenameResponse(
         override val ok: Boolean,
@@ -30,7 +32,10 @@ data class SuccessfulConversationsRenameResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.rename)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 @JacksonDataClass
 data class ErrorConversationsRenameResponse constructor(override val ok: Boolean,
@@ -40,7 +45,10 @@ data class ErrorConversationsRenameResponse constructor(override val ok: Boolean
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.rename)
+ * Renames a conversation.
+ *
+ * @property channel the channel-id of the channel you want to rename
+ * @property name the new name for the channel
  */
 data class ConversationsRenameRequest(@JsonProperty("channel") val channel: String,
                                       @JsonProperty("name") val name: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Replies.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Replies.kt
@@ -25,6 +25,9 @@ sealed class ConversationRepliesResponse constructor(@JsonProperty("ok") open va
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property messages the messages of the requested thread
+ * @property hasMore determines if more messages are available
+ * @property responseMetadata contains additional information, used for paging
  */
 @JacksonDataClass
 data class SuccessfulConversationRepliesResponse constructor(override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Replies.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Replies.kt
@@ -21,6 +21,11 @@ sealed class ConversationRepliesResponse constructor(@JsonProperty("ok") open va
     companion object
 }
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulConversationRepliesResponse constructor(override val ok: Boolean,
                                                              @JsonProperty("messages") val messages: List<Message>,
@@ -51,12 +56,29 @@ data class SuccessfulConversationRepliesResponse constructor(override val ok: Bo
                      @InstantToString @JsonProperty("ts") val timestamp: Instant)
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorConversationRepliesResponse constructor(override val ok: Boolean, @JsonProperty("error") val error: String)
     : ConversationRepliesResponse(ok) {
     companion object
 }
 
+/**
+ * Retrieve a thread of messages posted to a conversation
+ *
+ * @property channelId the channel-id of the channel that contains the thread
+ * @property timestamp the timestamp of the message
+ * @property cursor Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first "page" of the collection.
+ * @property inclusive Include messages with latest or oldest timestamp in results only when either timestamp is specified.
+ * @property latest End of time range of messages to include in results.
+ * @property limit The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.
+ * @property oldest Start of time range of messages to include in results.
+ */
 data class ConversationsRepliesRequest constructor(val channelId: String,
                                                    val timestamp: String,
                                                    val cursor: String? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetPurpose.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetPurpose.kt
@@ -21,6 +21,7 @@ sealed class ConversationSetPurposeResponse constructor(@JsonProperty("ok") open
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property purpose the new purpose
  */
 data class SuccessfulConversationSetPurposeResponse(
         override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetPurpose.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetPurpose.kt
@@ -17,6 +17,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ConversationSetPurposeResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 data class SuccessfulConversationSetPurposeResponse(
         override val ok: Boolean,
         @JsonProperty("purpose") val purpose: String
@@ -24,6 +29,12 @@ data class SuccessfulConversationSetPurposeResponse(
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorConversationSetPurposeResponse constructor(
         override val ok: Boolean,
@@ -33,7 +44,10 @@ data class ErrorConversationSetPurposeResponse constructor(
 }
 
 /**
- * Data Class that represents arguments as defined in https://api.slack.com/methods/conversations.setPurpose
+ * Sets the Purpose for a conversation.
+ *
+ * @property channel the channel-id of the channel you want to set the Purpose for
+ * @property purpose the purpose you want to set
  */
 data class ConversationsSetPurposeRequest(private val channel: String,
                                           private val purpose: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetTopic.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetTopic.kt
@@ -21,6 +21,7 @@ sealed class ConversationSetTopicResponse constructor(@JsonProperty("ok") open v
  * Success-response of this request.
  *
  * @property ok will be true
+ * @property topic the new topic
  */
 data class SuccessfulConversationSetTopicResponse(
         override val ok: Boolean,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetTopic.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/SetTopic.kt
@@ -17,6 +17,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ConversationSetTopicResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 data class SuccessfulConversationSetTopicResponse(
         override val ok: Boolean,
         @JsonProperty("topic") val topic: String
@@ -24,6 +29,12 @@ data class SuccessfulConversationSetTopicResponse(
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorConversationSetTopicResponse constructor(
         override val ok: Boolean,
@@ -33,7 +44,10 @@ data class ErrorConversationSetTopicResponse constructor(
 }
 
 /**
- * Data Class that represents arguments as defined in https://api.slack.com/methods/conversations.setTopic
+ * Sets the topic for a conversation.
+ *
+ * @property channel the channel-id of the channel you want to set the topic for
+ * @property purpose the topic you want to set
  */
 data class ConversationsSetTopicRequest(private val channel: String,
                                         private val topic: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Unarchive.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/conversations/Unarchive.kt
@@ -16,8 +16,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ConversationUnarchiveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.archive)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulConversationUnarchiveResponse(
         override val ok: Boolean) : ConversationUnarchiveResponse(ok) {
@@ -25,7 +28,10 @@ data class SuccessfulConversationUnarchiveResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.archive)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorConversationUnarchiveResponse constructor(
         override val ok: Boolean,
@@ -35,7 +41,9 @@ data class ErrorConversationUnarchiveResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/conversations.archive)
+ * Reverses conversation archival.
+ *
+ * @property channel the channel-id for the channel you want to unarchive
  */
 data class ConversationUnarchiveRequest(@JsonProperty("channel") val channel: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/dialog/Open.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/dialog/Open.kt
@@ -17,12 +17,24 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class SlackOpenDialogResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulOpenDialogResponse constructor(override val ok: Boolean)
     : SlackOpenDialogResponse(ok) {
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ * @property metadata additional information about the error
+ */
 @JacksonDataClass
 data class ErrorOpenDialogResponse constructor(override val ok: Boolean,
                                                @JsonProperty("error") val error: String,
@@ -33,6 +45,12 @@ data class ErrorOpenDialogResponse constructor(override val ok: Boolean,
 @JacksonDataClass
 data class MetaData constructor(@JsonProperty("messages") val messages: List<String>?)
 
+/**
+ * Open a dialog with a user
+ *
+ * @property dialog the dialog you want to open
+ * @property trigger_id the triggerId you receive by invoking a slashcommand or interactive component
+ */
 @JacksonDataClass
 data class SlackOpenDialogRequest constructor(@JsonProperty("dialog") val dialog: Dialog,
                                               @JsonProperty("trigger_id") val trigger_id: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Archive.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Archive.kt
@@ -17,7 +17,9 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsArchiveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.archive)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulGroupsArchiveResponse(
         override val ok: Boolean) : GroupsArchiveResponse(ok) {
@@ -25,7 +27,10 @@ data class SuccessfulGroupsArchiveResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.archive)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsArchiveResponse constructor(
         override val ok: Boolean,
@@ -35,7 +40,9 @@ data class ErrorGroupsArchiveResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.archive)
+ * Archives a group
+ *
+ * @property channelId the channel-id of the group you want to archive
  */
 data class GroupsArchiveRequest(@JsonProperty("channel") val channelId: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Create.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Create.kt
@@ -19,7 +19,10 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsCreateResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.Create)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property group the created group object
  */
 data class SuccessfulGroupsCreateResponse(
         override val ok: Boolean,
@@ -28,7 +31,10 @@ data class SuccessfulGroupsCreateResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.Create)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsCreateResponse constructor(
         override val ok: Boolean,
@@ -38,7 +44,10 @@ data class ErrorGroupsCreateResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.Create)
+ * Creates a group
+ *
+ * @property name the name of the group you want to create
+ * @property validate Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
  */
 data class GroupsCreateRequest(@JsonProperty("name") val name: String,
                                @JsonProperty("validate") val validate: Boolean = true) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/CreateChild.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/CreateChild.kt
@@ -19,7 +19,10 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsCreateChildResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.CreateChild)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property group the created child-group object
  */
 data class SuccessfulGroupsCreateChildResponse(
         override val ok: Boolean,
@@ -28,7 +31,10 @@ data class SuccessfulGroupsCreateChildResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.CreateChild)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsCreateChildResponse constructor(
         override val ok: Boolean,
@@ -38,7 +44,13 @@ data class ErrorGroupsCreateChildResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.CreateChild)
+ * This method takes an existing private channel and performs the following steps:
+ * - Renames the existing private channel (from "example" to "example-archived").
+ * - Archives the existing private channel.
+ * - Creates a new private channel with the name of the existing private channel.
+ * -  Adds all members of the existing private channel to the new private channel.
+ *
+ * @property channelId the channel-id of the group you want to re-create
  */
 data class GroupsCreateChildRequest(@JsonProperty("channel") val channelId: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/History.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/History.kt
@@ -20,7 +20,12 @@ import java.time.Instant
 sealed class GroupsHistoryResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.history)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property latestTimestamp the timestamp of the latest message
+ * @property messages list of history messages
+ * @property hasMore determines if more messages are available
  */
 data class SuccessfulGroupsHistoryResponse(
         override val ok: Boolean,
@@ -42,7 +47,10 @@ data class SuccessfulGroupsHistoryResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.history)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsHistoryResponse constructor(
         override val ok: Boolean,
@@ -52,7 +60,14 @@ data class ErrorGroupsHistoryResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.history)
+ * Lists past messages of the group
+ *
+ * @property channelId the channel-id of the group you want to request the past messages from
+ * @property count the amount of messages you want to request
+ * @property inclusive Include messages with latest or oldest timestamp in results.
+ * @property latestTimestamp  End of time range of messages to include in results.
+ * @property oldestTimestamp Start of time range of messages to include in results.
+ * @property unreads determines if unreads_count_display should be included in the response
  */
 data class GroupsHistoryRequest(@JsonProperty("channel") val channelId: String,
                                 @JsonProperty("count") val count: Int? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Info.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Info.kt
@@ -19,7 +19,10 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsInfoResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.info)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property group the information about the group
  */
 data class SuccessfulGroupsInfoResponse(
         override val ok: Boolean,
@@ -28,7 +31,10 @@ data class SuccessfulGroupsInfoResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.info)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsInfoResponse constructor(
         override val ok: Boolean,
@@ -38,7 +44,10 @@ data class ErrorGroupsInfoResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.info)
+ * Gets information about the group
+ *
+ * @property channelId the channel of which you want to request information about
+ * @property includeLocale determines if the locale of the group should be included
  */
 data class GroupsInfoRequest(@JsonProperty("channel") val channelId: String,
                              @JsonProperty("include_locale") val includeLocale: Boolean? = null) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Invite.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Invite.kt
@@ -21,7 +21,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsInviteResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.invite)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property group the new group object with the invited user
+ * @property userAlreadyInGroup determines if the user is already in the group
  */
 data class SuccessfulGroupsInviteResponse(override val ok: Boolean,
                                           @JsonProperty("group") val group: Group,
@@ -30,7 +34,10 @@ data class SuccessfulGroupsInviteResponse(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.invite)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsInviteResponse(override val ok: Boolean,
                                      @JsonProperty("error") val error: String) : GroupsInviteResponse(ok) {
@@ -38,7 +45,10 @@ data class ErrorGroupsInviteResponse(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.invite)
+ * Adds a user to a group
+ *
+ * @property channelId the channel id of the channel to which you want to add the user
+ * @property userId the user you want to add
  */
 data class GroupsInviteRequest(@JsonProperty("channel") val channelId: String,
                                @JsonProperty("user") val userId: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Kick.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Kick.kt
@@ -18,14 +18,19 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsKickResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.kick)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulGroupsKickResponse(override val ok: Boolean) : GroupsKickResponse(ok) {
     companion object
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.kick)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsKickResponse constructor(
         override val ok: Boolean,
@@ -35,7 +40,10 @@ data class ErrorGroupsKickResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.kick)
+ * Removes a user from a group
+ *
+ * @property channelId the channel id of the channel you want to remove the user from
+ * @property userId the user id you want to remove
  */
 data class GroupsKickRequest(@JsonProperty("channel") val channelId: String,
                              @JsonProperty("user") val userId: Boolean = true) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Leave.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Leave.kt
@@ -18,14 +18,19 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsLeaveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.leave)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulGroupsLeaveResponse(override val ok: Boolean) : GroupsLeaveResponse(ok) {
     companion object
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.leave)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsLeaveResponse constructor(
         override val ok: Boolean,
@@ -35,7 +40,9 @@ data class ErrorGroupsLeaveResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.leave)
+ * Leaves a Group
+ *
+ * @property channelId the channel-id of the group you want to leave
  */
 data class GroupsLeaveRequest(@JsonProperty("channel") val channelId: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/List.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/List.kt
@@ -20,7 +20,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsListResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.list)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property group list of available groups
+ * @property responseMetadata metadata used for paging
  */
 data class SuccessfulGroupsListResponse(
         override val ok: Boolean,
@@ -30,7 +34,10 @@ data class SuccessfulGroupsListResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.list)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsListResponse constructor(
         override val ok: Boolean,
@@ -40,7 +47,12 @@ data class ErrorGroupsListResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.list)
+ * Lists private channels that the calling user has access to.
+ *
+ * @property cursor Parameter for pagination. Set cursor equal to the next_cursor attribute returned by the previous request's response_metadata. This parameter is optional, but pagination is mandatory: the default value simply fetches the first "page" of the collection.
+ * @property excludeArchived determines if archived groups should be excluded
+ * @property excludeMembers determines if members should be excluded
+ * @property limit the max-count of groups you want to request
  */
 data class GroupsListRequest(@JsonProperty("cursor") val cursor: String,
                              @JsonProperty("exclude_archived") val excludeArchived: Boolean? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Mark.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Mark.kt
@@ -18,14 +18,19 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsMarkResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.mark)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulGroupsMarkResponse(override val ok: Boolean) : GroupsMarkResponse(ok) {
     companion object
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.mark)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsMarkResponse constructor(
         override val ok: Boolean,
@@ -35,7 +40,10 @@ data class ErrorGroupsMarkResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.mark)
+ * Sets the read cursor in a private channel.
+ *
+ * @property channelId the channel-id of the channel you want to mark
+ * @property timestamp the timestamp of the message, where the read cursor should point to
  */
 data class GroupsMarkRequest(@JsonProperty("channel") val channelId: String,
                              @JsonProperty("ts") val timestamp: Boolean = true) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Open.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Open.kt
@@ -18,7 +18,11 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsOpenResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.open)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property noOp true if the channel is already open
+ * @property isAlreadyOpen true if the channel is already open
  */
 data class SuccessfulGroupsOpenResponse(override val ok: Boolean,
                                         @JsonProperty("no_op") val noOp: Boolean? = null,
@@ -27,7 +31,10 @@ data class SuccessfulGroupsOpenResponse(override val ok: Boolean,
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.open)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsOpenResponse constructor(
         override val ok: Boolean,
@@ -37,7 +44,9 @@ data class ErrorGroupsOpenResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.open)
+ * Opens a private channel.
+ *
+ * @property channelId the channel-id of the group you want to open
  */
 data class GroupsOpenRequest(@JsonProperty("channel") val channelId: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Rename.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Rename.kt
@@ -19,7 +19,10 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsRenameResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.rename)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property group the renamed group object
  */
 data class SuccessfulGroupsRenameResponse(
         override val ok: Boolean,
@@ -28,7 +31,10 @@ data class SuccessfulGroupsRenameResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.rename)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsRenameResponse constructor(
         override val ok: Boolean,
@@ -38,7 +44,11 @@ data class ErrorGroupsRenameResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.rename)
+ * Renames a group
+ *
+ * @property channelId the channel-id of the group you want to rename
+ * @property newName the new name for the group
+ * @property validate Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
  */
 data class GroupsRenameRequest(@JsonProperty("channel") val channelId: String,
                                @JsonProperty("name") val newName: String,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Replies.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Replies.kt
@@ -20,16 +20,22 @@ import java.time.Instant
 sealed class GroupsRepliesResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.replies)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property messages list of thread messages
  */
 data class SuccessfulGroupsRepliesResponse(
         override val ok: Boolean,
-        @JsonProperty("messages") val group: List<SuccessfulGroupsHistoryResponse.Message>) : GroupsRepliesResponse(ok) {
+        @JsonProperty("messages") val messages: List<SuccessfulGroupsHistoryResponse.Message>) : GroupsRepliesResponse(ok) {
     companion object
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.replies)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsRepliesResponse constructor(
         override val ok: Boolean,
@@ -39,7 +45,10 @@ data class ErrorGroupsRepliesResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.replies)
+ * Returns the thread-messages of a thread in a group
+ *
+ * @property channel the channel-id of the channel that contains the thread
+ * @property threadTimestamp the timestamp of the thread
  */
 data class GroupsRepliesRequest(@JsonProperty("channel") val channel: String,
                                 @InstantToString @JsonProperty("thread_ts") val threadTimestamp: Instant) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/SetPurpose.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/SetPurpose.kt
@@ -18,7 +18,10 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsSetPurposeResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.setPurpose)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property newPurpose the new purpose
  */
 data class SuccessfulGroupsSetPurposeResponse(
         override val ok: Boolean,
@@ -27,7 +30,10 @@ data class SuccessfulGroupsSetPurposeResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.setPurpose)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsSetPurposeResponse constructor(
         override val ok: Boolean,
@@ -37,7 +43,10 @@ data class ErrorGroupsSetPurposeResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.setPurpose)
+ * Sets the purpose of a Group
+ *
+ * @property channelId the channel-id of the group you want to set the purpose for
+ * @property purpose the new purpose
  */
 data class GroupsSetPurposeRequest(@JsonProperty("channel") val channelId: String,
                                    @JsonProperty("purpose") val purpose: String) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/SetTopic.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/SetTopic.kt
@@ -19,7 +19,10 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsSetTopicResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.setTopic)
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property topic the new topic
  */
 data class SuccessfulGroupsSetTopicResponse(
         override val ok: Boolean,
@@ -28,7 +31,10 @@ data class SuccessfulGroupsSetTopicResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.setTopic)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsSetTopicResponse constructor(
         override val ok: Boolean,
@@ -38,7 +44,10 @@ data class ErrorGroupsSetTopicResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.setTopic)
+ * Sets the topic for a group
+ *
+ * @property channelId the channel-id of the group you want to set the topic for
+ * @property topic the new topic
  */
 data class GroupsSetTopicRequest(@JsonProperty("channel") val channelId: String,
                                  @JsonProperty("topic") val topic: Topic) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Unarchive.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/groups/Unarchive.kt
@@ -17,7 +17,9 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 sealed class GroupsUnarchiveResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.unarchive)
+ * Success-response of this request.
+ *
+ * @property ok will be true
  */
 data class SuccessfulGroupsUnarchiveResponse(
         override val ok: Boolean) : GroupsUnarchiveResponse(ok) {
@@ -25,7 +27,10 @@ data class SuccessfulGroupsUnarchiveResponse(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.unarchive)
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
  */
 data class ErrorGroupsUnarchiveResponse constructor(
         override val ok: Boolean,
@@ -35,7 +40,9 @@ data class ErrorGroupsUnarchiveResponse constructor(
 }
 
 /**
- * [SlackDoc](https://api.slack.com/methods/groups.unarchive)
+ * Unarchives a Group
+ *
+ * @property channelId the channel-id of the group you want to unarchive
  */
 data class GroupsUnarchiveRequest(@JsonProperty("channel") val channelId: String) {
     companion object

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Close.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Close.kt
@@ -18,22 +18,40 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ImCloseResponse constructor(@JsonProperty(value = "ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property noOp  true if the Im-Channel is already closed
+ * @property alreadyClosed true if the Im-Channel is already closed
+ */
 @JacksonDataClass
 data class SuccessfulImCloseResponse constructor(override val ok: Boolean,
                                                  @JsonProperty(value = "no_op") val noOp: Boolean?,
                                                  @JsonProperty(value = "already_closed") val alreadyClosed: Boolean?)
-    : ImCloseResponse(ok){
+    : ImCloseResponse(ok) {
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorImCloseResponse constructor(override val ok: Boolean,
                                             @JsonProperty(value = "error") val error: String)
-    : ImCloseResponse(ok){
+    : ImCloseResponse(ok) {
     companion object
 }
 
+/**
+ * Closes a im-channel
+ *
+ * @property channelId the channel of the im-channel you want to close
+ */
 @JacksonDataClass
-data class ImCloseRequest constructor(@JsonProperty(value = "channel") val channelId: String){
+data class ImCloseRequest constructor(@JsonProperty(value = "channel") val channelId: String) {
     companion object
 }

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/History.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/History.kt
@@ -19,6 +19,15 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ImHistoryResponse constructor(@JsonProperty(value = "ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property latest the timestamp of the latest message
+ * @property messages list of past messages
+ * @property hasMore determines if more messages are available
+ * @property isLimited only included for free teams that have reached the free message limit
+ */
 @JacksonDataClass
 data class SuccessfulImHistoryResponse constructor(override val ok: Boolean,
                                                    val latest: String,
@@ -38,6 +47,12 @@ data class SuccessfulImHistoryResponse constructor(override val ok: Boolean,
     }
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorImHistoryResponse constructor(override val ok: Boolean,
                                               val error: String)
@@ -45,6 +60,16 @@ data class ErrorImHistoryResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Fetches history messages of an im-channel
+ *
+ * @property channel the channel id of the channel you want to fetch history-messages from
+ * @property count the amoutn of messages to fetch
+ * @property inclusive Include messages with latest or oldest timestamp in results.
+ * @property latest End of time range of messages to include in results.
+ * @property oldest Start of time range of messages to include in results.
+ * @property unreadsInclude determines if unread_count_display should be included in the output
+ */
 data class ImHistoryRequest(private val channel: String,
                             private val count: Int? = null,
                             private val inclusive: Boolean? = false,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/List.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/List.kt
@@ -20,6 +20,13 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ImListResponse constructor(@JsonProperty(value = "ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property ims list of direct message channels
+ * @property responseMetadata metadata used for paging
+ */
 @JacksonDataClass
 data class SuccessfulImListResponse constructor(override val ok: Boolean,
                                                 @JsonProperty("ims") val ims: List<Im>,
@@ -47,6 +54,12 @@ data class ResponseMetadata(@JsonProperty("next_cursor") val nextCursor: String)
     companion object
 }
 
+/**
+ * Lists all available Im-Channels
+ *
+ * @property cursor paging cursor
+ * @property limit the limit of im-channels to fetch
+ */
 data class ImListRequest constructor(val cursor: String?,
                                      val limit: String?) {
     companion object {}

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Mark.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Mark.kt
@@ -20,12 +20,23 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ImMarkResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ */
 @JacksonDataClass
 data class SuccessfulImMarkResponse constructor(override val ok: Boolean)
     : ImMarkResponse(ok) {
     companion object
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorImMarkResponse constructor(override val ok: Boolean,
                                            @JsonProperty("error") val error: String)
@@ -33,6 +44,12 @@ data class ErrorImMarkResponse constructor(override val ok: Boolean,
     companion object
 }
 
+/**
+ * Sets the read cursor in a direct message channel.
+ *
+ * @property channel the channel-id on which the read-cursor should be set
+ * @property timestamp the timestamp of the message you want to set the read cursor to
+ */
 @JacksonDataClass
 data class ImMarkRequest constructor(@JsonProperty("channel") val channel: String,
                                      @InstantToString @JsonProperty("ts") val timestamp: Instant) {

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Open.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Open.kt
@@ -16,6 +16,12 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
 @JacksonDataClass
 sealed class ImOpenResponse constructor(@JsonProperty("ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property channel the opened direct-message channel
+ */
 @JacksonDataClass
 data class SuccessfulImOpenResponse constructor(override val ok: Boolean,
                                                 @JsonProperty("channel") val channel: Channel)
@@ -27,12 +33,25 @@ data class SuccessfulImOpenResponse constructor(override val ok: Boolean,
     }
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorImOpenResponse constructor(override val ok: Boolean, @JsonProperty("error") val error: String)
     : ImOpenResponse(ok) {
     companion object
 }
 
+/**
+ * Opens a direct message channel.
+ *
+ * @property user User to open a direct message channel with.
+ * @property includeLocale determines if the locale should be included in the response
+ * @property returnIm Boolean, indicates you want the full IM channel definition in the response.
+ */
 @JacksonDataClass
 data class ImOpenRequest constructor(@JsonProperty("user") val user: String,
                                      @JsonProperty("include_locale") val includeLocale: Boolean? = null,

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Replies.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/group/im/Replies.kt
@@ -21,6 +21,12 @@ import java.time.Instant
 @JacksonDataClass
 sealed class ImRepliesResponse constructor(@JsonProperty(value = "ok") open val ok: Boolean)
 
+/**
+ * Success-response of this request.
+ *
+ * @property ok will be true
+ * @property messages list of thread-messages
+ */
 @JacksonDataClass
 data class SuccessfulImRepliesResponse constructor(override val ok: Boolean,
                                                    @JsonProperty(value = "messages") val messages: List<Message>)
@@ -38,6 +44,12 @@ data class SuccessfulImRepliesResponse constructor(override val ok: Boolean,
     }
 }
 
+/**
+ * Failure-response of this request
+ *
+ * @property ok will be false
+ * @property error contains the error description
+ */
 @JacksonDataClass
 data class ErrorImRepliesResponse constructor(override val ok: Boolean,
                                               @JsonProperty(value = "error") val error: String)
@@ -46,7 +58,10 @@ data class ErrorImRepliesResponse constructor(override val ok: Boolean,
 }
 
 /**
- * DataClass that represents arguments as defined in https://api.slack.com/methods/im.replies
+ * Fetches thread-messages of a message in a direct-message channel
+ *
+ * @property channel the channel-id of the direct-message channel that contains the thread
+ * @property thread_ts the timestamp of the thread
  */
 data class ImRepliesRequest(private val channel: String,
                             private val thread_ts: String) {


### PR DESCRIPTION
Instead of using the somewhat annoying to configure and barely (out-of-the-box) working dokka-plugin there is a jar you can use in order to generate the docs via command line.


`java -jar dokka-fatjar.jar /Users/<username>/Kreait/slack-spring-boot-starter/data/slack-jackson-dto/src`

is sufficient to generate the html files for the dto group


Quote:
To run Dokka from the command line, download the [Dokka jar](https://github.com/Kotlin/dokka/releases/download/0.9.10/dokka-fatjar.jar).
To generate documentation, run the following command:

    java -jar dokka-fatjar.jar <source directories> <arguments>

Dokka supports the following command line arguments:

  * `-output` - the output directory where the documentation is generated
  * `-format` - the [output format](#output-formats):
  * `-classpath` - list of directories or .jar files to include in the classpath (used for resolving references)
  * `-samples` - list of directories containing sample code (documentation for those directories is not generated but declarations from them can be referenced using the `@sample` tag)
  * `-module` - the name of the module being documented (used as the root directory of the generated documentation)
  * `-include` - names of files containing the documentation for the module and individual packages
  * `-nodeprecated` - if set, deprecated elements are not included in the generated documentation
  * `-impliedPlatforms` - list of implied platforms (comma-separated)
  * `-packageOptions` - list of package options in format `prefix,-deprecated,-privateApi,+warnUndocumented;...` 
  * `-links` - external documentation links in format `url^packageListUrl^^url2...`
  * `-noStdlibLink` - disable linking to online kotlin-stdlib documentation
  * `-noJdkLink` - disable linking to online JDK documentation
  * `-cacheRoot` - use `default` or set to custom path to cache directory to enable package-list caching. When set to `default`, caches stored in $USER_HOME/.cache/dokka
