### PR TITLE
remove libs.olaph.io

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,6 @@ Add the following to your *build.gradle* file
 
 [source]
 --
-repositories { maven { url "https://libs.olaph.io" } }
 
 dependencies {
     implementation(group: "com.kreait.slack", name: "slack-spring-boot-starter", version: "{version}")

--- a/docs/slack-spring-boot-docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/slack-spring-boot-docs/src/main/asciidoc/getting-started.adoc
@@ -35,11 +35,10 @@ Add the following to your *build.gradle* file
 
 [source]
 --
-repositories { maven { url "https://libs.olaph.io" } }
 
 dependencies {
-//we add changing true because we are working with changing milestone versions at the moment
-implementation(group: "com.kreait.slack", name: "slack-spring-boot-starter", version: "{version}", changing: true) }
+implementation(group: "com.kreait.slack", name: "slack-spring-boot-starter", version: "{version}")
+}
 --
 
 Add the following properties to the *application.properties* file


### PR DESCRIPTION
sdk is now available on maven, libs.olaph is not needed anymore