### PR TITLE
added api_app_id field to slackCommand

### DIFF
--- a/data/slack-jackson-dto-test-extensions/src/main/kotlin/com/kreait/slack/api/contract/jackson/SlackCommandExtension.kt
+++ b/data/slack-jackson-dto-test-extensions/src/main/kotlin/com/kreait/slack/api/contract/jackson/SlackCommandExtension.kt
@@ -1,5 +1,6 @@
 package com.kreait.slack.api.contract.jackson
 
+import com.kreait.slack.api.contract.jackson.SlackCommand.Companion.API_APP_ID_PROPERTY_NAME
 import com.kreait.slack.api.contract.jackson.SlackCommand.Companion.CHANNEL_ID_PROPERTY_NAME
 import com.kreait.slack.api.contract.jackson.SlackCommand.Companion.CHANNEL_NAME_PROPERTY_NAME
 import com.kreait.slack.api.contract.jackson.SlackCommand.Companion.COMMAND_PROPERTY_NAME
@@ -26,7 +27,8 @@ fun SlackCommand.Companion.sample(): SlackCommand {
             "",
             "",
             null,
-            null
+            null,
+            ""
     )
 }
 
@@ -44,6 +46,7 @@ fun SlackCommand.toParameterMap(): Map<String, List<String>> {
     parameterMap[TEXT_PROPERTY_NAME] = listOf(text)
     parameterMap[RESPONSE_URL_PROPERTY_NAME] = listOf(responseUrl)
     parameterMap[TRIGGER_ID_PROPERTY_NAME] = listOf(triggerId)
+    parameterMap[API_APP_ID_PROPERTY_NAME] = listOf(apiAppId)
 
     enterpriseId?.let { parameterMap[TRIGGER_ID_PROPERTY_NAME] = listOf(it) }
     enterpriseName?.let { parameterMap[TRIGGER_ID_PROPERTY_NAME] = listOf(it) }

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/SlackCommand.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/SlackCommand.kt
@@ -19,6 +19,7 @@ import com.kreait.slack.api.contract.jackson.util.JacksonDataClass
  * @property triggerId the trigger id which is used to open a dialog
  * @property enterpriseId the enterprise id which is only present, when the workspace is contained in the enterprise grid
  * @property enterpriseName the enterprise name which is only present, when the workspace is contained in the enterprise grid
+ * @property apiAppId the slack apps Id. Can be used for handling commands from multiple applications or environments.
  */
 @JacksonDataClass
 data class SlackCommand constructor(@JsonProperty(TOKEN_PROPERTY_NAME) val token: String,
@@ -33,7 +34,8 @@ data class SlackCommand constructor(@JsonProperty(TOKEN_PROPERTY_NAME) val token
                                     @JsonProperty(RESPONSE_URL_PROPERTY_NAME) val responseUrl: String,
                                     @JsonProperty(TRIGGER_ID_PROPERTY_NAME) val triggerId: String,
                                     @JsonProperty(ENTERPRISE_ID_PROPERTY_NAME) val enterpriseId: String?,
-                                    @JsonProperty(ENTERPRISE_NAME_PROPERTY_NAME) val enterpriseName: String?) {
+                                    @JsonProperty(ENTERPRISE_NAME_PROPERTY_NAME) val enterpriseName: String?,
+                                    @JsonProperty(API_APP_ID_PROPERTY_NAME) val apiAppId: String) {
     companion object {
         const val TOKEN_PROPERTY_NAME = "token"
         const val TEAM_ID_PROPERTY_NAME = "team_id"
@@ -48,5 +50,6 @@ data class SlackCommand constructor(@JsonProperty(TOKEN_PROPERTY_NAME) val token
         const val TRIGGER_ID_PROPERTY_NAME = "trigger_id"
         const val ENTERPRISE_ID_PROPERTY_NAME = "enterprise_id"
         const val ENTERPRISE_NAME_PROPERTY_NAME = "enterprise_name"
+        const val API_APP_ID_PROPERTY_NAME = "api_app_id"
     }
 }

--- a/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/util/JacksonDataClass.kt
+++ b/data/slack-jackson-dto/src/main/kotlin/com/kreait/slack/api/contract/jackson/util/JacksonDataClass.kt
@@ -3,6 +3,7 @@ package com.kreait.slack.api.contract.jackson.util
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 
 @Retention(AnnotationRetention.RUNTIME)
@@ -13,4 +14,5 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder
         getterVisibility = JsonAutoDetect.Visibility.NONE,
         isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonCreator
+@JsonIgnoreProperties(ignoreUnknown = true)
 annotation class JacksonDataClass


### PR DESCRIPTION
Will add the api_app_id field to the SlackCommand DTO and thus prevent errors from missing field
